### PR TITLE
Fix close account instruction data

### DIFF
--- a/server/src/main/kotlin/com/bswap/server/data/solana/transaction/CustomMethod.kt
+++ b/server/src/main/kotlin/com/bswap/server/data/solana/transaction/CustomMethod.kt
@@ -31,11 +31,25 @@ fun createCloseAccountInstruction(
     return TransactionInstruction(
         programId = SolanaPublicKey(Base58.decode(programId.base58())),
         keys = listOf(
-            AccountMeta(SolanaPublicKey(Base58.decode(tokenAccount.base58())), isSigner = false, isWritable = true),
-            AccountMeta(SolanaPublicKey(Base58.decode(destination.base58())), isSigner = false, isWritable = true),
-            AccountMeta(SolanaPublicKey(Base58.decode(destination.base58())), isSigner = true, isWritable = false),
+            AccountMeta(
+                SolanaPublicKey(Base58.decode(tokenAccount.base58())),
+                isSigner = false,
+                isWritable = true
+            ),
+            AccountMeta(
+                SolanaPublicKey(Base58.decode(destination.base58())),
+                isSigner = false,
+                isWritable = true
+            ),
+            AccountMeta(
+                SolanaPublicKey(Base58.decode(destination.base58())),
+                isSigner = true,
+                isWritable = false
+            ),
         ),
-        data = ByteArray(8) { 9.toByte() }
+        // The SPL token program expects a single byte instruction id for
+        // `CloseAccount`. Using 8 bytes caused malformed transactions.
+        data = byteArrayOf(9.toByte())
     )
 }
 


### PR DESCRIPTION
## Summary
- correct the token account close instruction

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68416fa452108333815e40159a259505