### PR TITLE
Update README for JDK 17 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@
 
 ## Requirements
 
-- **Kotlin 1.7+** (or Java 11+)
-- **Gradle** (or Maven) for dependency management
+- **Kotlin 1.9+ with JDK 17**
+- **Gradle** (or Maven) for dependency management. Gradle's toolchain will automatically use JDK 17 if it is installed or configured.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- update README requirements to state Kotlin 1.9+ with JDK 17
- clarify that Gradle toolchains will automatically use JDK 17 when available

## Testing
- `./gradlew --version`
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew :server:test` *(fails to compile project)*

------
https://chatgpt.com/codex/tasks/task_e_684b359e3a1c8333a7bcd2de585acc6b