### PR TITLE
Load Solana private key from env or file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
    - **RPC endpoint**  
    - **JupiterSwapService**  
    - **JitoBundlerService** (if desired, set `useJito = true`)
+   - **Private key** via the `SOLANA_PRIVATE_KEY` environment variable or a `solana_private_key.txt` file
 3. **Build** the project:
    ```bash
    ./gradlew server:run

--- a/server/src/main/kotlin/com/bswap/server/SolanaSwapBotConfig.kt
+++ b/server/src/main/kotlin/com/bswap/server/SolanaSwapBotConfig.kt
@@ -2,6 +2,7 @@ package com.bswap.server
 
 import foundation.metaplex.solanapublickeys.PublicKey
 import java.math.BigDecimal
+import java.io.File
 
 data class SolanaSwapBotConfig(
     val walletPublicKey: PublicKey = PublicKey(""),
@@ -18,5 +19,8 @@ data class SolanaSwapBotConfig(
     val useJito: Boolean = true
 )
 
-const val privateKey: String =
-    ""
+val privateKey: String by lazy {
+    System.getenv("SOLANA_PRIVATE_KEY")?.takeIf { it.isNotBlank() }
+        ?: runCatching { File("solana_private_key.txt").readText().trim() }.getOrNull()
+        ?: ""
+}


### PR DESCRIPTION
## Summary
- make `privateKey` load from `SOLANA_PRIVATE_KEY` or `solana_private_key.txt`
- document the new configuration option

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0f0bd758833393f33314d2881c57