### PR TITLE
Use lifecycle coroutine scope

### DIFF
--- a/server/src/main/kotlin/com/bswap/server/data/dexscreener/DexScreenerRepository.kt
+++ b/server/src/main/kotlin/com/bswap/server/data/dexscreener/DexScreenerRepository.kt
@@ -5,7 +5,6 @@ import com.bswap.server.data.dexscreener.models.PairsResponse
 import com.bswap.server.data.dexscreener.models.TokenBoost
 import com.bswap.server.data.dexscreener.models.TokenProfile
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,7 +18,7 @@ const val autoRefreshInterval = 5_000L
 class DexScreenerRepository(
     private val client: DexScreenerClient,
     private val rateLimiter: DexScreenerRateLimiter = DexScreenerRateLimiter(),
-    private val coroutineScope: CoroutineScope = GlobalScope
+    private val coroutineScope: CoroutineScope
 ) {
 
     fun startAutoRefreshAll(


### PR DESCRIPTION
## Summary
- pass a `CoroutineScope` into `DexScreenerRepository`
- provide an application scope in `Application.kt` and use it to start bot jobs
- launch coroutines with the injected scope
- remove `GlobalScope`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0f0d982483338a33035eee2eb07d