### PR TITLE
Make endpoints configurable via environment vars

### DIFF
--- a/server/src/main/kotlin/com/bswap/server/Constants.kt
+++ b/server/src/main/kotlin/com/bswap/server/Constants.kt
@@ -1,6 +1,12 @@
 package com.bswap.server
 
-const val SERVER_PORT = 9090
+import com.bswap.server.config.ServerConfig
+
+/**
+ * Configuration constants. Endpoint URLs are read from environment variables via
+ * [ServerConfig] so they can be customised without code changes.
+ */
+val SERVER_PORT: Int = System.getenv("SERVER_PORT")?.toIntOrNull() ?: 9090
 const val LAMPORTS_PER_SOL = 1_000_000_000L // 1 billion lamports per SOL
-const val RPC_URL = "https://yolo-fluent-glitter.solana-mainnet.quiknode.pro/2624c5dac7235db7aa8c9f0bc1b297af251f93ee"
-const val JUPITER_API_URL = "https://quote-api.jup.ag/v6"
+val RPC_URL: String = ServerConfig.rpcUrl
+val JUPITER_API_URL: String = ServerConfig.jupiterApiUrl

--- a/server/src/main/kotlin/com/bswap/server/config/ServerConfig.kt
+++ b/server/src/main/kotlin/com/bswap/server/config/ServerConfig.kt
@@ -1,0 +1,32 @@
+package com.bswap.server.config
+
+/**
+ * Simple configuration object that reads endpoint URLs from environment variables.
+ * Defaults match the previously hard coded values so existing behaviour does not change
+ * when no environment variables are provided.
+ */
+object ServerConfig {
+    val rpcUrl: String = System.getenv("RPC_URL")
+        ?: "https://yolo-fluent-glitter.solana-mainnet.quiknode.pro/2624c5dac7235db7aa8c9f0bc1b297af251f93ee"
+    val jupiterApiUrl: String = System.getenv("JUPITER_API_URL") ?: "https://quote-api.jup.ag/v6"
+
+    val dexTokenProfilesUrl: String = System.getenv("DEX_TOKEN_PROFILES_URL")
+        ?: "https://api.dexscreener.com/token-profiles/latest/v1"
+    val dexTokenBoostsLatestUrl: String = System.getenv("DEX_TOKEN_BOOSTS_LATEST_URL")
+        ?: "https://api.dexscreener.com/token-boosts/latest/v1"
+    val dexTokenBoostsTopUrl: String = System.getenv("DEX_TOKEN_BOOSTS_TOP_URL")
+        ?: "https://api.dexscreener.com/token-boosts/top/v1"
+    val dexOrdersBaseUrl: String = System.getenv("DEX_ORDERS_BASE_URL") ?: "https://api.dexscreener.com/orders/v1"
+    val dexPairsBaseUrl: String = System.getenv("DEX_PAIRS_BASE_URL") ?: "https://api.dexscreener.com/latest/dex"
+
+    val jitoBundlerEndpoints: List<String> = (System.getenv("JITO_BUNDLER_ENDPOINTS")
+        ?: "https://mainnet.block-engine.jito.wtf/api/v1/bundles,https://amsterdam.mainnet.block-engine.jito.wtf/api/v1/bundles,https://frankfurt.mainnet.block-engine.jito.wtf/api/v1/bundles,https://ny.mainnet.block-engine.jito.wtf/api/v1/bundles,https://tokyo.mainnet.block-engine.jito.wtf/api/v1/bundles,https://slc.mainnet.block-engine.jito.wtf/api/v1/bundles")
+        .split(',').map { it.trim() }
+
+    val pumpFunWsUrl: String = System.getenv("PUMPFUN_WS_URL") ?: "wss://pumpportal.fun/api/data"
+    val pumpFunBaseUrl: String = System.getenv("PUMPFUN_BASE_URL") ?: "https://frontend-api.pump.fun/coins"
+
+    val logMonitorUrl: String = System.getenv("LOG_MONITOR_URL") ?: "https://api.mainnet-beta.solana.com"
+    val poolMonitorUrl: String = System.getenv("POOL_MONITOR_URL")
+        ?: "https://api-v3.raydium.io/pools/info/list?poolType=all&poolSortField=default&sortType=desc&pageSize=10&page=1"
+}

--- a/server/src/main/kotlin/com/bswap/server/data/dexscreener/DexScreenerClient.kt
+++ b/server/src/main/kotlin/com/bswap/server/data/dexscreener/DexScreenerClient.kt
@@ -1,5 +1,6 @@
 package com.bswap.server.data.dexscreener
 
+import com.bswap.server.config.ServerConfig
 import com.bswap.server.data.dexscreener.models.Order
 import com.bswap.server.data.dexscreener.models.PairsResponse
 import com.bswap.server.data.dexscreener.models.TokenBoost
@@ -19,13 +20,14 @@ interface DexScreenerClient {
     suspend fun searchPairs(query: String): PairsResponse
 }
 
-class DexScreenerClientImpl(private val httpClient: HttpClient) : DexScreenerClient {
-
-    private val tokenProfilesUrl = "https://api.dexscreener.com/token-profiles/latest/v1"
-    private val tokenBoostsLatestUrl = "https://api.dexscreener.com/token-boosts/latest/v1"
-    private val tokenBoostsTopUrl = "https://api.dexscreener.com/token-boosts/top/v1"
-    private val ordersBaseUrl = "https://api.dexscreener.com/orders/v1"
-    private val pairsBaseUrl = "https://api.dexscreener.com/latest/dex"
+class DexScreenerClientImpl(
+    private val httpClient: HttpClient,
+    private val tokenProfilesUrl: String = ServerConfig.dexTokenProfilesUrl,
+    private val tokenBoostsLatestUrl: String = ServerConfig.dexTokenBoostsLatestUrl,
+    private val tokenBoostsTopUrl: String = ServerConfig.dexTokenBoostsTopUrl,
+    private val ordersBaseUrl: String = ServerConfig.dexOrdersBaseUrl,
+    private val pairsBaseUrl: String = ServerConfig.dexPairsBaseUrl,
+) : DexScreenerClient {
 
     override suspend fun getTokenProfiles(): List<TokenProfile> =
         httpClient.get(tokenProfilesUrl).body()

--- a/server/src/main/kotlin/com/bswap/server/data/solana/jito/JitoBundlerService.kt
+++ b/server/src/main/kotlin/com/bswap/server/data/solana/jito/JitoBundlerService.kt
@@ -1,5 +1,6 @@
 package com.bswap.server.data.solana.jito
 
+import com.bswap.server.config.ServerConfig
 import foundation.metaplex.base58.encodeToBase58String
 import io.ktor.client.HttpClient
 import io.ktor.client.request.post
@@ -34,15 +35,8 @@ class JitoBundlerService(
     // Queue to hold base58-encoded transactions until we bundle them
     private val txQueue = LinkedList<String>()
 
-    // Jito endpoints
-    private val endpoints = listOf(
-        "https://mainnet.block-engine.jito.wtf/api/v1/bundles",
-        "https://amsterdam.mainnet.block-engine.jito.wtf/api/v1/bundles",
-        "https://frankfurt.mainnet.block-engine.jito.wtf/api/v1/bundles",
-        "https://ny.mainnet.block-engine.jito.wtf/api/v1/bundles",
-        "https://tokyo.mainnet.block-engine.jito.wtf/api/v1/bundles",
-        "https://slc.mainnet.block-engine.jito.wtf/api/v1/bundles"
-    )
+    // Jito endpoints can be customised via the JITO_BUNDLER_ENDPOINTS env variable
+    private val endpoints = ServerConfig.jitoBundlerEndpoints
 
     init {
         // 1) Background loop flushes the queue periodically

--- a/server/src/main/kotlin/com/bswap/server/data/solana/pumpfun/PumpFunService.kt
+++ b/server/src/main/kotlin/com/bswap/server/data/solana/pumpfun/PumpFunService.kt
@@ -1,6 +1,7 @@
 package com.bswap.server.data.solana.pumpfun
 
 import com.bswap.server.client
+import com.bswap.server.config.ServerConfig
 import com.bswap.server.data.ws.WebSocketState
 import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
 import io.ktor.client.plugins.websocket.webSocket
@@ -23,7 +24,7 @@ import kotlinx.serialization.json.jsonObject
 
 object PumpFunService {
 
-    private const val WS_URL = "wss://pumpportal.fun/api/data"
+    private val WS_URL = ServerConfig.pumpFunWsUrl
     private val eventFlow = MutableSharedFlow<TokenTradeResponse>()
     private val stateFlow = MutableStateFlow<WebSocketState>(WebSocketState.Disconnected)
     private val subscribedTokens = mutableSetOf<String>()

--- a/server/src/main/kotlin/com/bswap/server/data/solana/pumpfun/Validators.kt
+++ b/server/src/main/kotlin/com/bswap/server/data/solana/pumpfun/Validators.kt
@@ -1,6 +1,7 @@
 package com.bswap.server.data.solana.pumpfun
 
 import com.bswap.server.client
+import com.bswap.server.config.ServerConfig
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import kotlinx.coroutines.delay
@@ -15,7 +16,7 @@ data class PumpFunResponse(
 
 suspend fun isTokenValid(mint: String): Boolean = runCatching {
     delay(10_000)
-    val apiUrl = "https://frontend-api.pump.fun/coins/$mint"
+    val apiUrl = "${ServerConfig.pumpFunBaseUrl}/$mint"
     val response: PumpFunResponse = client.get(apiUrl).body()
     val currentTime = System.currentTimeMillis()
     val ageSeconds = (currentTime - response.created_timestamp) / 1000

--- a/server/src/main/kotlin/com/bswap/server/data/solana/search/logs/LogMonitorService.kt
+++ b/server/src/main/kotlin/com/bswap/server/data/solana/search/logs/LogMonitorService.kt
@@ -4,6 +4,7 @@ import io.ktor.client.*
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.statement.HttpResponse
+import com.bswap.server.config.ServerConfig
 import kotlinx.coroutines.delay
 import org.slf4j.LoggerFactory
 
@@ -19,7 +20,7 @@ class LogMonitorService(private val client: HttpClient) {
 
     suspend fun fetchLogs(): List<String> {
         // Replace this URL with the appropriate RPC or log-fetching API
-        val url = "https://api.mainnet-beta.solana.com"
+        val url = ServerConfig.logMonitorUrl
         val response: HttpResponse = client.get(url) {
             // Additional request parameters or authentication if needed
         }

--- a/server/src/main/kotlin/com/bswap/server/data/solana/search/pool/PoolMonitorService.kt
+++ b/server/src/main/kotlin/com/bswap/server/data/solana/search/pool/PoolMonitorService.kt
@@ -1,5 +1,6 @@
 package com.bswap.server.data.solana.search.pool
 
+import com.bswap.server.config.ServerConfig
 import com.bswap.server.data.solana.search.pool.model.Pool
 import com.bswap.server.data.solana.search.pool.model.PoolResponse
 import io.ktor.client.HttpClient
@@ -17,8 +18,7 @@ class PoolMonitorService(private val client: HttpClient) {
     private val logger = LoggerFactory.getLogger(PoolMonitorService::class.java)
 
     suspend fun fetchPools(): List<Pool> {
-        val url =
-            "https://api-v3.raydium.io/pools/info/list?poolType=all&poolSortField=default&sortType=desc&pageSize=10&page=1"
+        val url = ServerConfig.poolMonitorUrl
         val response: HttpResponse = client.get(url)
         val parsedResponse = response.body<PoolResponse>()
         if (parsedResponse.success) {


### PR DESCRIPTION
## Summary
- create `ServerConfig` to read endpoint URLs from env vars
- use `ServerConfig` for all network endpoints in the server module

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0f0fca908333a179e2b66efe160f