### PR TITLE
Refactor swap flow to return unsigned tx

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     // this is necessary to avoid the plugins to be loaded multiple times
     // in each subproject's classloader
     alias(libs.plugins.kotlinJvm) apply false
-    kotlin("plugin.serialization") version "1.9.24"
+    kotlin("plugin.serialization") version "2.1.21"
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -6,7 +6,8 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.composeMultiplatform)
-    kotlin("plugin.serialization") version "1.9.24"
+    alias(libs.plugins.composeCompiler)
+    kotlin("plugin.serialization") version "2.1.21"
 }
 
 kotlin {
@@ -67,6 +68,7 @@ kotlin {
             implementation(libs.kotlinx.datetime)
             implementation(libs.androidx.navigation3.runtime)
             implementation(libs.androidx.navigation3.ui)
+            implementation(project(":shared"))
         }
         wasmJsMain.dependencies {
             implementation(libs.ktor.client.js)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
 agp = "8.5.2"
 junit = "4.13.2"
-kotlin = "1.9.24"
+kotlin = "2.1.21"
 ktor = "3.0.2"
 logback = "1.5.11"
 kotlinx-html = "0.11.0"
-kotlin-serealization = "1.6.3"
+kotlin-serealization = "1.8.1"
 android-compileSdk = "34"
 android-minSdk = "24"
 android-targetSdk = "34"

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.ktor)
     application
-    kotlin("plugin.serialization") version "1.9.24"
+    kotlin("plugin.serialization") version "2.1.21"
 }
 
 group = "com.bswap.server"
@@ -44,4 +44,5 @@ dependencies {
     implementation(libs.kotlinx.html.jvm)
 
     implementation(libs.sol4k)
+    implementation(project(":shared"))
 }

--- a/server/src/main/kotlin/com/bswap/server/Application.kt
+++ b/server/src/main/kotlin/com/bswap/server/Application.kt
@@ -6,12 +6,20 @@ import com.bswap.server.data.solana.pumpfun.PumpFunService
 import com.bswap.server.routes.apiRoute
 import com.bswap.server.routes.startRoute
 import com.bswap.server.routes.tokensRoute
+import com.bswap.server.routes.walletRoutes
+import com.bswap.server.data.solana.jito.JitoBundlerService
+import com.bswap.server.data.solana.rpc.SolanaRpcClient
+import com.bswap.server.data.solana.swap.jupiter.JupiterSwapService
+import com.bswap.server.data.tokenlist.TokenListRepo
+import com.bswap.server.service.WalletService
 import foundation.metaplex.rpc.RPC
 import foundation.metaplex.rpc.networking.NetworkDriver
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
 import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.application.install
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
@@ -28,10 +36,14 @@ fun main() {
     bot.runDexScreenerSwap(tokenBoostedProfiles = false)
     bot.observePumpFun(PumpFunService.observeEvents())
     embeddedServer(Netty, port = SERVER_PORT) {
+        install(ContentNegotiation) {
+            json(Json { ignoreUnknownKeys = true })
+        }
         routing {
             startRoute()
             tokensRoute(dexScreenerRepository.tokenProfilesFlow)
             apiRoute(dexScreenerRepository.tokenProfilesFlow)
+            walletRoutes(walletService)
         }
     }.start(wait = true)
 }
@@ -65,7 +77,7 @@ fun SolanaTokenSwapBot.runDexScreenerSwap(
 val client by lazy {
     HttpClient(CIO) {
         install(WebSockets)
-        install(ContentNegotiation) {
+        install(ClientContentNegotiation) {
             json(Json { ignoreUnknownKeys = true })
         }
     }
@@ -74,6 +86,26 @@ val client by lazy {
 val rpc = createRPC(client)
 
 val dexScreenerRepository = DexScreenerRepository(DexScreenerClientImpl(client))
+
+val walletService = WalletService(
+    SolanaRpcClient(client),
+    TokenListRepo(client),
+    JupiterSwapService(client),
+    JitoBundlerService(
+        client = client,
+        jitoFeeLamports = 1000,
+        tipAccounts = listOf(
+            "Cw8CFyM9FkoMi7K7Crf6HNQqf4uEMzpKw6QNghXLvLkY",
+            "DttWaMuVvTiduZRnguLF7jNxTgiMBZ1hyAumKUiL2KRL",
+            "96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5",
+            "3AVi9Tg9Uo68tJfuvoKvqKNWKkC5wPdSSdeBnizKZ6jT",
+            "HFqU5x63VTqvQss8hp11i4wVV8bD44PvwucfZ2bU7gRe",
+            "ADaUMid9yfUytqMBgopwjb2DTLSokTSzL1zt6iGPaS49",
+            "ADuUkR4vqLUMWXxW9gh6D6L8pMSawimctcNZ5pGwDcEt",
+            "DfXygSm4jCyNCybVYYK6DwvWqjKee8pbDmJGcLWNDXjh"
+        )
+    )
+)
 
 private fun createRPC(client: HttpClient) =
     RPC(RPC_URL, NetworkDriver(client))

--- a/server/src/main/kotlin/com/bswap/server/SolanaTokenSwapBot.kt
+++ b/server/src/main/kotlin/com/bswap/server/SolanaTokenSwapBot.kt
@@ -182,9 +182,10 @@ class SolanaTokenSwapBot(
             runCatching {
                 // Attempt the Jupiter swap
                 jupiterSwapService.getQuoteAndPerformSwap(
-                    config.solAmountToTrade,
+                    config.solAmountToTrade.toPlainString(),
                     config.swapMint.base58(),
-                    mint
+                    mint,
+                    config.walletPublicKey.base58()
                 )
             }.onSuccess { swap ->
                 // If Jupiter provided no instructions, remove it from map
@@ -239,7 +240,8 @@ class SolanaTokenSwapBot(
                 jupiterSwapService.getQuoteAndPerformSwap(
                     info.tokenAmount.amount,
                     mint,
-                    config.swapMint.base58()
+                    config.swapMint.base58(),
+                    config.walletPublicKey.base58()
                 )
             }.onSuccess { swap ->
                 if (swap.swapTransaction == null) {
@@ -321,7 +323,8 @@ class SolanaTokenSwapBot(
                     jupiterSwapService.getQuoteAndPerformSwap(
                         token.tokenAmount.amount,
                         token.mint,
-                        config.swapMint.base58()
+                        config.swapMint.base58(),
+                        config.walletPublicKey.base58()
                     )
                 }.onSuccess { swap ->
                     if (swap.swapTransaction == null) return@onSuccess

--- a/server/src/main/kotlin/com/bswap/server/data/solana/rpc/SolanaRpcClient.kt
+++ b/server/src/main/kotlin/com/bswap/server/data/solana/rpc/SolanaRpcClient.kt
@@ -1,0 +1,64 @@
+package com.bswap.server.data.solana.rpc
+
+import com.bswap.server.RPC_URL
+import com.bswap.shared.model.TokenInfo
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.long
+import org.slf4j.LoggerFactory
+import kotlin.system.measureTimeMillis
+
+class SolanaRpcClient(
+    private val client: HttpClient,
+    private val rpcUrl: String = RPC_URL,
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    suspend fun getBalance(address: String): Long {
+        val body = """{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getBalance\",\"params\":[\"$address\"]}"""
+        lateinit var text: String
+        val time = measureTimeMillis {
+            text = client.post(rpcUrl) {
+                contentType(ContentType.Application.Json)
+                setBody(body)
+            }.bodyAsText()
+        }
+        logger.debug("getBalance latency=${time}ms")
+        return runCatching {
+            json.parseToJsonElement(text).jsonObject["result"]!!.jsonObject["value"]!!.jsonPrimitive.long
+        }.getOrDefault(0L)
+    }
+
+    suspend fun getSPLTokens(owner: String): List<TokenInfo> {
+        val req = """{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getTokenAccountsByOwner\",\"params\":[\"$owner\",{\"programId\":\"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA\"},{\"encoding\":\"jsonParsed\"}]}"""
+        lateinit var text: String
+        val time = measureTimeMillis {
+            text = client.post(rpcUrl) {
+                contentType(ContentType.Application.Json)
+                setBody(req)
+            }.bodyAsText()
+        }
+        logger.debug("getSPLTokens latency=${time}ms")
+        val element = runCatching { json.parseToJsonElement(text) }.getOrNull() ?: return emptyList()
+        val values = element.jsonObject["result"]?.jsonObject?.get("value")?.jsonArray ?: return emptyList()
+        return values.mapNotNull { item ->
+            runCatching {
+                val info = item.jsonObject["account"]!!.jsonObject["data"]!!.jsonObject["parsed"]!!.jsonObject["info"]!!.jsonObject
+                val mint = info["mint"]!!.jsonPrimitive.content
+                val amount = info["tokenAmount"]!!.jsonObject["amount"]!!.jsonPrimitive.content
+                val decimals = info["tokenAmount"]!!.jsonObject["decimals"]!!.jsonPrimitive.int
+                TokenInfo(mint = mint, amount = amount, decimals = decimals)
+            }.getOrNull()
+        }
+    }
+}

--- a/server/src/main/kotlin/com/bswap/server/data/tokenlist/TokenListRepo.kt
+++ b/server/src/main/kotlin/com/bswap/server/data/tokenlist/TokenListRepo.kt
@@ -1,0 +1,46 @@
+package com.bswap.server.data.tokenlist
+
+import com.bswap.shared.model.TokenInfo
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+import kotlin.system.measureTimeMillis
+
+class TokenListRepo(
+    private val client: HttpClient,
+    private val url: String = "https://token.jup.ag/all",
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val mutex = Mutex()
+    @Volatile
+    private var cache: List<TokenInfo>? = null
+    private val json = Json { ignoreUnknownKeys = true }
+
+    suspend fun getAll(): List<TokenInfo> {
+        cache?.let { return it }
+        return refresh()
+    }
+
+    suspend fun search(query: String): List<TokenInfo> {
+        val tokens = getAll()
+        return tokens.filter {
+            it.symbol?.contains(query, ignoreCase = true) == true ||
+                it.name?.contains(query, ignoreCase = true) == true
+        }
+    }
+
+    private suspend fun refresh(): List<TokenInfo> = mutex.withLock {
+        cache?.let { return it }
+        var data: List<TokenInfo> = emptyList()
+        val time = measureTimeMillis {
+            data = client.get(url).body()
+        }
+        logger.debug("token list refresh latency=${time}ms")
+        cache = data
+        return data
+    }
+}

--- a/server/src/main/kotlin/com/bswap/server/routes/Routes.kt
+++ b/server/src/main/kotlin/com/bswap/server/routes/Routes.kt
@@ -1,0 +1,69 @@
+package com.bswap.server.routes
+
+import com.bswap.shared.model.ApiError
+import com.bswap.shared.model.SwapRequest
+import com.bswap.shared.model.BatchSwapRequest
+import com.bswap.shared.model.SignedTx
+import com.bswap.server.service.WalletService
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+
+fun Route.walletRoutes(service: WalletService) {
+    get("/wallet/{address}/balance") {
+        val address = call.parameters["address"] ?: return@get call.respond(
+            HttpStatusCode.BadRequest,
+            ApiError("missing address")
+        )
+        val result = service.getBalance(address)
+        result.onSuccess { call.respond(it) }
+            .onFailure { call.respond(HttpStatusCode.InternalServerError, ApiError(it.message ?: "error")) }
+    }
+
+    get("/wallet/{address}/tokens") {
+        val address = call.parameters["address"] ?: return@get call.respond(
+            HttpStatusCode.BadRequest,
+            ApiError("missing address")
+        )
+        val result = service.getTokens(address)
+        result.onSuccess { call.respond(it) }
+            .onFailure { call.respond(HttpStatusCode.InternalServerError, ApiError(it.message ?: "error")) }
+    }
+
+    get("/tokens/search") {
+        val q = call.request.queryParameters["q"] ?: return@get call.respond(
+            HttpStatusCode.BadRequest,
+            ApiError("missing q")
+        )
+        val result = service.searchTokens(q)
+        result.onSuccess { call.respond(it) }
+            .onFailure { call.respond(HttpStatusCode.InternalServerError, ApiError(it.message ?: "error")) }
+    }
+
+    post("/swap") {
+        val req = call.receive<SwapRequest>()
+        val result = service.swap(req)
+        result.onSuccess { call.respond(it) }
+            .onFailure { call.respond(HttpStatusCode.InternalServerError, ApiError(it.message ?: "error")) }
+    }
+
+    post("/swapBatch") {
+        val req = call.receive<BatchSwapRequest>()
+        val result = service.swapBatch(req.swaps)
+        result.onSuccess { call.respond(it) }
+            .onFailure { call.respond(HttpStatusCode.InternalServerError, ApiError(it.message ?: "error")) }
+    }
+
+    post("/submitTx") {
+        val tx = call.receive<SignedTx>()
+        val result = service.submit(tx)
+        result.onSuccess { call.respond(HttpStatusCode.OK) }
+            .onFailure {
+                call.respond(HttpStatusCode.InternalServerError, ApiError(it.message ?: "error"))
+            }
+    }
+}

--- a/server/src/main/kotlin/com/bswap/server/service/WalletService.kt
+++ b/server/src/main/kotlin/com/bswap/server/service/WalletService.kt
@@ -1,0 +1,98 @@
+package com.bswap.server.service
+
+import com.bswap.server.data.solana.rpc.SolanaRpcClient
+import com.bswap.server.data.solana.swap.jupiter.JupiterSwapService
+import com.bswap.server.data.tokenlist.TokenListRepo
+import com.bswap.server.data.solana.jito.JitoBundlerService
+import com.bswap.shared.model.*
+import org.slf4j.LoggerFactory
+
+class WalletService(
+    private val rpcClient: SolanaRpcClient,
+    private val tokenRepo: TokenListRepo,
+    private val jupiter: JupiterSwapService,
+    private val jito: JitoBundlerService,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    sealed class Failure {
+        data class Rpc(val message: String) : Failure()
+        data class Jupiter(val message: String) : Failure()
+        data class TokenList(val message: String) : Failure()
+    }
+
+    suspend fun getBalance(address: String): Result<Long> = try {
+        Result.success(rpcClient.getBalance(address))
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    suspend fun getTokens(address: String): Result<List<TokenInfo>> = try {
+        Result.success(rpcClient.getSPLTokens(address))
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    suspend fun walletInfo(address: String): Result<WalletInfo> = try {
+        val balance = rpcClient.getBalance(address)
+        val tokens = rpcClient.getSPLTokens(address)
+        Result.success(WalletInfo(address, balance, tokens))
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    suspend fun searchTokens(query: String): Result<List<TokenInfo>> = try {
+        Result.success(tokenRepo.search(query))
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    suspend fun swap(request: SwapRequest): Result<SwapTx> = try {
+        val response = jupiter.getQuoteAndPerformSwap(
+            request.amount,
+            request.inputMint,
+            request.outputMint,
+            request.owner
+        )
+        val txBase64 = response.swapTransaction
+            ?: return Result.failure(Exception("no route"))
+        Result.success(
+            SwapTx(
+                transaction = txBase64,
+                lastValidBlockHeight = response.lastValidBlockHeight,
+                prioritizationFeeLamports = response.prioritizationFeeLamports
+            )
+        )
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    suspend fun swapBatch(requests: List<SwapRequest>): Result<List<SwapTx>> = try {
+        val results = requests.mapNotNull { req ->
+            val resp = jupiter.getQuoteAndPerformSwap(
+                req.amount,
+                req.inputMint,
+                req.outputMint,
+                req.owner
+            )
+            resp.swapTransaction?.let {
+                SwapTx(
+                    transaction = it,
+                    lastValidBlockHeight = resp.lastValidBlockHeight,
+                    prioritizationFeeLamports = resp.prioritizationFeeLamports
+                )
+            }
+        }
+        Result.success(results)
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    suspend fun submit(tx: SignedTx): Result<Unit> = try {
+        val bytes = java.util.Base64.getDecoder().decode(tx.transaction)
+        jito.enqueue(bytes)
+        Result.success(Unit)
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,3 +30,4 @@ dependencyResolutionManagement {
 
 include(":server")
 include(":composeApp")
+include(":shared")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.androidLibrary)
+    kotlin("plugin.serialization") version "2.1.21"
+}
+
+kotlin {
+    androidTarget()
+    jvm()
+    wasmJs()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(libs.kotlinx.serialization.json)
+            }
+        }
+        val jvmMain by getting
+        val androidMain by getting
+        val wasmJsMain by getting
+    }
+}
+
+android {
+    namespace = "com.bswap.shared"
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    defaultConfig {
+        minSdk = libs.versions.android.minSdk.get().toInt()
+        targetSdk = libs.versions.android.targetSdk.get().toInt()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/bswap/shared/model/Models.kt
+++ b/shared/src/commonMain/kotlin/com/bswap/shared/model/Models.kt
@@ -1,0 +1,50 @@
+package com.bswap.shared.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TokenInfo(
+    val mint: String,
+    val symbol: String? = null,
+    val name: String? = null,
+    val decimals: Int? = null,
+    val amount: String? = null,
+    val logoUri: String? = null,
+)
+
+@Serializable
+data class WalletInfo(
+    val address: String,
+    val lamports: Long,
+    val tokens: List<TokenInfo>,
+)
+
+@Serializable
+data class SwapRequest(
+    val owner: String,
+    val inputMint: String,
+    val outputMint: String,
+    val amount: String,
+)
+
+@Serializable
+data class BatchSwapRequest(
+    val swaps: List<SwapRequest>,
+)
+
+@Serializable
+data class SignedTx(
+    val transaction: String,
+)
+
+@Serializable
+data class SwapTx(
+    val transaction: String,
+    val lastValidBlockHeight: Long? = null,
+    val prioritizationFeeLamports: Long? = null,
+)
+
+@Serializable
+data class ApiError(
+    val message: String,
+)


### PR DESCRIPTION
## Summary
- return more data with `SwapTx` so clients can sign locally
- remove server-side signing from `JupiterSwapService`
- update bot and wallet service to pass user public key to Jupiter

## Testing
- `./gradlew :server:classes --no-daemon`
- `./gradlew :composeApp:assemble --no-daemon` *(fails: Cannot find a Java installation matching languageVersion 17)*

------
https://chatgpt.com/codex/tasks/task_e_684f0f11c5e88333be41bf117c8d9623