### PR TITLE
Fix Compose navigation build setup

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
+    kotlin("plugin.parcelize")
     kotlin("plugin.serialization") version "2.1.21"
 }
 
@@ -66,8 +67,6 @@ kotlin {
             implementation(libs.coil.mp)
             implementation(libs.coil.network.ktor)
             implementation(libs.kotlinx.datetime)
-            implementation(libs.androidx.navigation3.runtime)
-            implementation(libs.androidx.navigation3.ui)
             implementation(project(":shared"))
         }
         wasmJsMain.dependencies {

--- a/composeApp/src/commonMain/kotlin/com/bswap/navigation/BackStack.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/navigation/BackStack.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.Composable
 
+@Composable
 fun rememberBackStack(start: NavKey = NavKey.Welcome): SnapshotStateList<NavKey> = rememberSaveable {
     mutableStateListOf(start)
 }

--- a/composeApp/src/commonMain/kotlin/com/bswap/navigation/BswapNavHost.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/navigation/BswapNavHost.kt
@@ -2,7 +2,7 @@ package com.bswap.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.snapshots.SnapshotStateList
-import androidx.navigation3.NavDisplay
+import com.bswap.navigation.NavDisplay
 import com.bswap.ui.account.AccountSettingsScreen
 import com.bswap.ui.onboarding.ChoosePathScreen
 import com.bswap.ui.onboarding.OnboardingWelcomeScreen
@@ -10,7 +10,6 @@ import com.bswap.ui.seed.ConfirmSeedScreen
 import com.bswap.ui.seed.GenerateSeedScreen
 import com.bswap.ui.wallet.ImportWalletScreen
 import com.bswap.ui.wallet.WalletHomeScreen
-import androidx.compose.animation.AnimatedContentScope.SlideDirection
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 

--- a/composeApp/src/commonMain/kotlin/com/bswap/navigation/NavDisplay.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/navigation/NavDisplay.kt
@@ -1,0 +1,29 @@
+package com.bswap.navigation
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.togetherWith
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.snapshots.SnapshotStateList
+
+@Composable
+fun <T> NavDisplay(
+    backStack: SnapshotStateList<T>,
+    enter: (AnimatedContentTransitionScope<T>.() -> EnterTransition)? = null,
+    exit: (AnimatedContentTransitionScope<T>.() -> ExitTransition)? = null,
+    content: @Composable (T) -> Unit
+) {
+    val current = backStack.last()
+    AnimatedContent(
+        targetState = current,
+        transitionSpec = {
+            val ent = enter?.invoke(this) ?: EnterTransition.None
+            val ex = exit?.invoke(this) ?: ExitTransition.None
+            ent togetherWith ex
+        }
+    ) { target ->
+        content(target)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,6 @@ coil3 = "3.0.4"
 metaplex = "0.3.0-beta1"
 sol4k = "0.5.4"
 kotlinx-datetime = "0.5.0"
-navigation3 = "3.0.0-alpha02"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -40,8 +39,6 @@ androidx-lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecy
 androidx-lifecycle-viewmodel = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
-androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3" }
-androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
 
 
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }


### PR DESCRIPTION
## Summary
- add parcelize plugin for Compose module
- drop unsupported `androidx.navigation3` dependency
- implement a simple `NavDisplay` helper
- update navigation code to use the helper
- mark `rememberBackStack` as a composable

## Testing
- `./gradlew assembleDebug` *(fails: SDK licenses not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_684f25b34bf88333a11e120ae30ce1a8