### PR TITLE
Fix toolchain downloads

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
 dependencyResolutionManagement {
     repositories {
         google {


### PR DESCRIPTION
## Summary
- enable foojay toolchain resolver plugin so Gradle can download Java toolchains

## Testing
- `./gradlew tasks --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684f38f38d3883338b7cfc88e3d87fb5