### PR TITLE
Fix Compose preview imports

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -53,7 +53,7 @@ kotlin {
             implementation(compose.materialIconsExtended)
             implementation(compose.ui)
             implementation(compose.components.resources)
-            implementation(compose.components.uiToolingPreview)
+            implementation(compose.preview)
             implementation(libs.androidx.lifecycle.viewmodel)
             implementation(libs.androidx.lifecycle.viewmodel.compose)
             implementation(libs.androidx.lifecycle.runtime.compose)

--- a/composeApp/src/commonMain/kotlin/com/bswap/app/ComposeApp.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/app/ComposeApp.kt
@@ -6,7 +6,7 @@ import com.bswap.navigation.BswapNavHost
 import com.bswap.navigation.NavKey
 import com.bswap.navigation.rememberBackStack
 import com.bswap.ui.UiTheme
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 
 /**
  * Entry composable launching the Bswap navigation flow.

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/UiButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/UiButton.kt
@@ -4,7 +4,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 
 @Composable
 fun UiButton(

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/UiCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/UiCard.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 
 @Composable
 fun UiCard(

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/UiCheckbox.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/UiCheckbox.kt
@@ -3,7 +3,7 @@ package com.bswap.ui
 import androidx.compose.material3.Checkbox
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 
 @Composable
 fun UiCheckbox(

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/UiFloatingActionButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/UiFloatingActionButton.kt
@@ -6,7 +6,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 
 @Composable
 fun UiFloatingActionButton(

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/UiIconButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/UiIconButton.kt
@@ -6,7 +6,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 
 @Composable
 fun UiIconButton(

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/UiProgressIndicators.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/UiProgressIndicators.kt
@@ -4,7 +4,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 
 @Composable
 fun UiCircularProgressIndicator(

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/UiRadioButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/UiRadioButton.kt
@@ -3,7 +3,7 @@ package com.bswap.ui
 import androidx.compose.material3.RadioButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 
 @Composable
 fun UiRadioButton(

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/UiSlider.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/UiSlider.kt
@@ -3,7 +3,7 @@ package com.bswap.ui
 import androidx.compose.material3.Slider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 
 @Composable
 fun UiSlider(

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/UiSwitch.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/UiSwitch.kt
@@ -3,7 +3,7 @@ package com.bswap.ui
 import androidx.compose.material3.Switch
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 
 @Composable
 fun UiSwitch(

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/UiTextField.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/UiTextField.kt
@@ -4,7 +4,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 
 @Composable
 fun UiTextField(

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/account/AccountHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/account/AccountHeader.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bswap.ui.UiButton
 import com.bswap.ui.UiTheme
@@ -49,7 +49,7 @@ fun AccountHeader(
     }
 }
 
-@Preview(name = "AccountHeader", device = "id:pixel_4", showBackground = true)
+@Preview
 @Composable
 private fun AccountHeaderPreview() {
     UiTheme {

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/account/AccountSettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/account/AccountSettingsScreen.kt
@@ -14,7 +14,7 @@ import com.bswap.navigation.NavKey
 import com.bswap.navigation.rememberBackStack
 import com.bswap.navigation.replaceAll
 import androidx.compose.runtime.snapshots.SnapshotStateList
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bswap.ui.UiTheme
 
@@ -52,7 +52,7 @@ fun AccountSettingsScreen(
     }
 }
 
-@Preview(name = "AccountSettingsScreen", device = "id:pixel_4", showBackground = true)
+@Preview
 @Composable
 private fun AccountSettingsScreenPreview() {
     UiTheme {

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/actions/PrimaryActionBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/actions/PrimaryActionBar.kt
@@ -9,7 +9,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bswap.ui.UiButton
 import com.bswap.ui.UiTheme
@@ -38,7 +38,7 @@ fun PrimaryActionBar(
     }
 }
 
-@Preview(name = "PrimaryActionBar", device = "id:pixel_4", showBackground = true)
+@Preview
 @Composable
 private fun PrimaryActionBarPreview() {
     UiTheme {

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/balance/BalanceCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/balance/BalanceCard.kt
@@ -12,7 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bswap.ui.UiTheme
 
@@ -66,7 +66,7 @@ fun BalanceCard(
     }
 }
 
-@Preview(name = "BalanceCard", device = "id:pixel_4", showBackground = true)
+@Preview
 @Composable
 private fun BalanceCardPreview() {
     UiTheme {

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/onboarding/ChoosePathScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/onboarding/ChoosePathScreen.kt
@@ -11,7 +11,7 @@ import com.bswap.navigation.NavKey
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.bswap.navigation.rememberBackStack
 import com.bswap.navigation.push
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bswap.ui.UiButton
 import com.bswap.ui.UiTheme
@@ -36,7 +36,7 @@ fun ChoosePathScreen(
     }
 }
 
-@Preview(name = "ChoosePathScreen", device = "id:pixel_4", showBackground = true)
+@Preview
 @Composable
 private fun ChoosePathScreenPreview() {
     UiTheme {

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/onboarding/OnboardingStepper.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/onboarding/OnboardingStepper.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.bswap.ui.UiTheme
@@ -68,7 +68,7 @@ private fun StepItem(text: String, active: Boolean, size: Dp = 16.dp) {
     }
 }
 
-@Preview(name = "Stepper", device = "id:pixel_4", showBackground = true)
+@Preview
 @Composable
 private fun OnboardingStepperPreview() {
     UiTheme {

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/onboarding/OnboardingWelcomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/onboarding/OnboardingWelcomeScreen.kt
@@ -14,7 +14,7 @@ import com.bswap.navigation.NavKey
 import com.bswap.navigation.rememberBackStack
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.bswap.navigation.push
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bswap.ui.UiButton
 import com.bswap.ui.UiTheme
@@ -42,7 +42,7 @@ fun OnboardingWelcomeScreen(
     }
 }
 
-@Preview(name = "OnboardingWelcomeScreen", device = "id:pixel_4", showBackground = true)
+@Preview
 @Composable
 private fun OnboardingWelcomeScreenPreview() {
     UiTheme {

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/ConfirmSeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/ConfirmSeedScreen.kt
@@ -15,7 +15,7 @@ import com.bswap.navigation.NavKey
 import com.bswap.navigation.rememberBackStack
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.bswap.navigation.replaceAll
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bswap.ui.UiButton
 import com.bswap.ui.UiTheme
@@ -60,7 +60,7 @@ fun ConfirmSeedScreen(
     }
 }
 
-@Preview(name = "ConfirmSeedScreen", device = "id:pixel_4", showBackground = true)
+@Preview
 @Composable
 private fun ConfirmSeedScreenPreview() {
     UiTheme {

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/GenerateSeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/GenerateSeedScreen.kt
@@ -15,7 +15,7 @@ import com.bswap.navigation.rememberBackStack
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.bswap.navigation.push
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bswap.ui.UiButton
 import com.bswap.ui.UiTheme
@@ -47,7 +47,7 @@ fun GenerateSeedScreen(
     }
 }
 
-@Preview(name = "GenerateSeedScreen", device = "id:pixel_4", showBackground = true)
+@Preview
 @Composable
 private fun GenerateSeedScreenPreview() {
     UiTheme {

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/SeedInputField.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/SeedInputField.kt
@@ -16,7 +16,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardCapitalization
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 import com.bswap.ui.UiTheme
 
 /**
@@ -55,7 +55,7 @@ fun SeedInputField(
     }
 }
 
-@Preview(name = "SeedInput", device = "id:pixel_4", showBackground = true)
+@Preview
 @Composable
 private fun SeedInputFieldPreview() {
     var text by remember { mutableStateOf("word1 word2 word3") }

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/SeedRevealDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/SeedRevealDialog.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bswap.ui.UiButton
 import com.bswap.ui.UiTheme
@@ -65,7 +65,7 @@ fun SeedRevealDialog(
     }
 }
 
-@Preview(name = "SeedRevealDialog", device = "id:pixel_4", showBackground = true)
+@Preview
 @Composable
 private fun SeedRevealDialogPreview() {
     UiTheme {

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/SeedWordChip.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/SeedWordChip.kt
@@ -7,7 +7,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bswap.ui.UiTheme
 
@@ -37,7 +37,7 @@ fun SeedWordChip(
     )
 }
 
-@Preview(name = "SeedWordChip", device = "id:pixel_4", showBackground = true)
+@Preview
 @Composable
 private fun SeedWordChipPreview() {
     UiTheme {

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/token/TokenChip.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/token/TokenChip.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bswap.ui.UiTheme
 
@@ -45,7 +45,7 @@ fun TokenChip(
     }
 }
 
-@Preview(name = "TokenChip", device = "id:pixel_4", showBackground = true)
+@Preview
 @Composable
 private fun TokenChipPreview() {
     UiTheme {

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/tx/TransactionRow.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/tx/TransactionRow.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bswap.ui.UiTheme
 
@@ -51,7 +51,7 @@ fun TransactionRow(tx: SolanaTx, modifier: Modifier = Modifier) {
     }
 }
 
-@Preview(name = "TransactionRow", device = "id:pixel_4", showBackground = true)
+@Preview
 @Composable
 private fun TransactionRowPreview() {
     UiTheme {

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/wallet/ImportWalletScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/wallet/ImportWalletScreen.kt
@@ -13,7 +13,7 @@ import com.bswap.navigation.NavKey
 import com.bswap.navigation.rememberBackStack
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.bswap.navigation.replaceAll
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bswap.ui.UiButton
 import com.bswap.ui.UiTheme
@@ -39,7 +39,7 @@ fun ImportWalletScreen(
     }
 }
 
-@Preview(name = "ImportWalletScreen", device = "id:pixel_4", showBackground = true)
+@Preview
 @Composable
 private fun ImportWalletScreenPreview() {
     UiTheme {

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/wallet/WalletHomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/wallet/WalletHomeScreen.kt
@@ -14,7 +14,7 @@ import com.bswap.navigation.NavKey
 import com.bswap.navigation.rememberBackStack
 import com.bswap.navigation.push
 import androidx.compose.runtime.snapshots.SnapshotStateList
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bswap.ui.UiTheme
 import com.bswap.ui.actions.PrimaryActionBar
@@ -54,7 +54,7 @@ fun WalletHomeScreen(
     }
 }
 
-@Preview(name = "WalletHomeScreen", device = "id:pixel_4", showBackground = true)
+@Preview
 @Composable
 private fun WalletHomeScreenPreview() {
     UiTheme {

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/widgets/QrAddressTextField.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/widgets/QrAddressTextField.kt
@@ -12,7 +12,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.desktop.ui.tooling.preview.Preview
 import com.bswap.ui.UiTheme
 
 private val base58Regex = Regex("^[1-9A-HJ-NP-Za-km-z]+")
@@ -43,7 +43,7 @@ fun QrAddressTextField(
     )
 }
 
-@Preview(name = "QrAddressTextField", device = "id:pixel_4", showBackground = true)
+@Preview
 @Composable
 private fun QrAddressTextFieldPreview() {
     val (text, setText) = remember { mutableStateOf("") }


### PR DESCRIPTION
## Summary
- use desktop preview annotation package
- drop preview parameters unsupported on desktop

## Testing
- `./gradlew :composeApp:compileKotlinDesktop --no-daemon --stacktrace`
- `./gradlew test --no-daemon --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f452517bc83338a6b910fa3858239