### PR TITLE
Refine onboarding UI design

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/Buttons.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/Buttons.kt
@@ -1,0 +1,68 @@
+package com.bswap.ui
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun PrimaryButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    height: Dp = 56.dp
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        shape = ButtonDefaults.shape,
+        border = BorderStroke(1.dp, Color.White),
+        colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent)
+    ) {
+        Box(
+            modifier = Modifier
+                .background(
+                    brush = Brush.radialGradient(
+                        listOf(Color.White, UiColors.accentGray),
+                        radius = 400f
+                    ),
+                    alpha = 1f
+                )
+                .fillMaxWidth(0.8f)
+                .height(height),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text.uppercase())
+        }
+    }
+}
+
+@Composable
+fun SecondaryButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        shape = ButtonDefaults.shape,
+        colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
+        border = BorderStroke(1.dp, Color.White)
+    ) { Text(text) }
+}

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/CardSurface.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/CardSurface.kt
@@ -1,0 +1,25 @@
+package com.bswap.ui
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CardSurface(
+    modifier: Modifier = Modifier,
+    elevation: Dp = 8.dp,
+    content: @Composable () -> Unit
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(containerColor = UiColors.surface),
+        shape = CardDefaults.shape,
+        elevation = CardDefaults.cardElevation(elevation),
+        border = BorderStroke(1.dp, Color.White)
+    ) { content() }
+}

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/UiColors.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/UiColors.kt
@@ -1,0 +1,14 @@
+package com.bswap.ui
+
+import androidx.compose.ui.graphics.Color
+
+object UiColors {
+    val primaryForeground = Color(0xFFFFFFFF)
+    val background = Color(0xFF000000)
+    val surface = Color(0xFF101010)
+    val accentGray = Color(0xFFAAAAAA)
+    val divider = Color(0xFF333333)
+    val error = Color(0xFFFF5252)
+    val success = Color(0xFF4CAF50)
+    val glow = Color(0x59FFFFFF) // rgba(255,255,255,0.35)
+}

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/UiTheme.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/UiTheme.kt
@@ -1,9 +1,10 @@
 package com.bswap.ui
 
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Typography
 import androidx.compose.material3.Shapes
+import androidx.compose.material3.Typography
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
@@ -11,25 +12,25 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 
 private val DarkColorPalette = darkColorScheme(
-    primary = Color(0xFFBB86FC),
-    secondary = Color(0xFF03DAC5),
-    background = Color(0xFF121212),
-    surface = Color(0xFF121212),
+    primary = UiColors.primaryForeground,
+    secondary = UiColors.accentGray,
+    background = UiColors.background,
+    surface = UiColors.surface,
     onPrimary = Color.Black,
     onSecondary = Color.Black,
-    onBackground = Color.White,
-    onSurface = Color.White,
+    onBackground = UiColors.primaryForeground,
+    onSurface = UiColors.primaryForeground,
 )
 
 private val LightColorPalette = lightColorScheme(
-    primary = Color(0xFF6200EE),
-    secondary = Color(0xFF03DAC5),
-    background = Color(0xFFFFFFFF),
-    surface = Color(0xFFFFFFFF),
-    onPrimary = Color.White,
+    primary = UiColors.primaryForeground,
+    secondary = UiColors.accentGray,
+    background = UiColors.background,
+    surface = UiColors.surface,
+    onPrimary = Color.Black,
     onSecondary = Color.Black,
-    onBackground = Color.Black,
-    onSurface = Color.Black,
+    onBackground = UiColors.primaryForeground,
+    onSurface = UiColors.primaryForeground,
 )
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/onboarding/ChoosePathScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/onboarding/ChoosePathScreen.kt
@@ -13,7 +13,8 @@ import com.bswap.navigation.rememberBackStack
 import com.bswap.navigation.push
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.bswap.ui.UiButton
+import com.bswap.ui.PrimaryButton
+import com.bswap.ui.SecondaryButton
 import com.bswap.ui.UiTheme
 
 /**
@@ -31,8 +32,8 @@ fun ChoosePathScreen(
             .testTag(NavKey.ChoosePath::class.simpleName!!),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        UiButton(text = "Create", onClick = { backStack.push(NavKey.GenerateSeed) }, modifier = Modifier.fillMaxWidth())
-        UiButton(text = "Import", onClick = { backStack.push(NavKey.ImportWallet) }, modifier = Modifier.fillMaxWidth())
+        PrimaryButton(text = "Create", onClick = { backStack.push(NavKey.GenerateSeed) }, modifier = Modifier.fillMaxWidth())
+        SecondaryButton(text = "Import", onClick = { backStack.push(NavKey.ImportWallet) }, modifier = Modifier.fillMaxWidth())
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/onboarding/OnboardingWelcomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/onboarding/OnboardingWelcomeScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.bswap.navigation.push
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.bswap.ui.UiButton
+import com.bswap.ui.PrimaryButton
 import com.bswap.ui.UiTheme
 
 /**
@@ -38,7 +38,7 @@ fun OnboardingWelcomeScreen(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text("Welcome to Bswap", style = MaterialTheme.typography.headlineMedium)
-        UiButton(text = "\u041d\u0430\u0447\u0430\u0442\u044c", onClick = { backStack.push(NavKey.ChoosePath) }, modifier = Modifier.fillMaxWidth())
+        PrimaryButton(text = "\u041d\u0430\u0447\u0430\u0442\u044c", onClick = { backStack.push(NavKey.ChoosePath) }, modifier = Modifier.fillMaxWidth())
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/ConfirmSeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/ConfirmSeedScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.bswap.navigation.replaceAll
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.bswap.ui.UiButton
+import com.bswap.ui.PrimaryButton
 import com.bswap.ui.UiTheme
 
 /**
@@ -51,7 +51,7 @@ fun ConfirmSeedScreen(
                 )
             }
         }
-        UiButton(
+        PrimaryButton(
             text = "Confirm",
             onClick = { backStack.replaceAll(NavKey.WalletHome("pubKey")) },
             modifier = Modifier.fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/GenerateSeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/GenerateSeedScreen.kt
@@ -17,7 +17,8 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.bswap.navigation.push
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.bswap.ui.UiButton
+import androidx.compose.material3.TextButton
+import com.bswap.ui.PrimaryButton
 import com.bswap.ui.UiTheme
 
 /**
@@ -42,8 +43,8 @@ fun GenerateSeedScreen(
                 SeedWordChip(word = word, focused = false, onClick = {})
             }
         }
-        UiButton(text = "Copy", onClick = {}, modifier = Modifier.fillMaxWidth())
-        UiButton(text = "Next", onClick = { backStack.push(NavKey.ConfirmSeed(seedWords)) }, modifier = Modifier.fillMaxWidth())
+        TextButton(onClick = {}) { androidx.compose.material3.Text("Copy") }
+        PrimaryButton(text = "Next", onClick = { backStack.push(NavKey.ConfirmSeed(seedWords)) }, modifier = Modifier.fillMaxWidth())
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/wallet/ImportWalletScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/wallet/ImportWalletScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.bswap.navigation.replaceAll
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.bswap.ui.UiButton
+import com.bswap.ui.PrimaryButton
 import com.bswap.ui.UiTheme
 import com.bswap.ui.seed.SeedInputField
 
@@ -35,7 +35,7 @@ fun ImportWalletScreen(
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         SeedInputField(value = text, onValueChange = setText, modifier = Modifier.fillMaxWidth())
-        UiButton(text = "Import", onClick = { backStack.replaceAll(NavKey.WalletHome("pubKey")) }, modifier = Modifier.fillMaxWidth())
+        PrimaryButton(text = "Import", onClick = { backStack.replaceAll(NavKey.WalletHome("pubKey")) }, modifier = Modifier.fillMaxWidth())
     }
 }
 


### PR DESCRIPTION
## Summary
- implement new color palette and theme helpers
- add gradient `PrimaryButton` and `SecondaryButton`
- create `CardSurface`
- apply updated components in onboarding and seed screens
- switch import screen button to `PrimaryButton`

## Testing
- `./gradlew build -x wasmJsBrowserTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f50f48f4c8333afe10d8b6fee0996