### PR TITLE
Fix build errors

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/bswap/data/SeedStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/bswap/data/SeedStorage.android.kt
@@ -2,7 +2,7 @@ package com.bswap.data
 
 import android.content.Context
 import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.preferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.security.crypto.MasterKey
 import com.bswap.app.appContext
@@ -18,8 +18,8 @@ private val Context.dataStore by preferencesDataStore("seed_store")
 actual fun seedStorage(): SeedStorage = AndroidSeedStorage(appContext)
 
 private class AndroidSeedStorage(private val context: Context) : SeedStorage {
-    private val seedKey = preferencesKey<String>("seed")
-    private val pubKey = preferencesKey<String>("pub_key")
+    private val seedKey = stringPreferencesKey("seed")
+    private val pubKey = stringPreferencesKey("pub_key")
     private val masterKey = MasterKey.Builder(context)
         .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
         .build()
@@ -27,7 +27,7 @@ private class AndroidSeedStorage(private val context: Context) : SeedStorage {
     private fun secretKey(): SecretKey {
         val keyBytes = ByteArray(32)
         SecureRandom().nextBytes(keyBytes)
-        return SecretKeySpec(masterKey.keyStoreAlias.toByteArray(), 0, 32, "AES")
+        return SecretKeySpec(masterKey.alias.toByteArray(), 0, 32, "AES")
     }
 
     private fun encrypt(data: String): String {

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/ConfirmSeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/ConfirmSeedScreen.kt
@@ -23,6 +23,7 @@ import com.bswap.ui.UiTheme
 import com.bswap.seed.SeedUtils
 import com.bswap.seed.JitoService
 import com.bswap.data.seedStorage
+import org.sol4k.toBase58
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.input.pointer.pointerInput
@@ -32,6 +33,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.launch
 import androidx.compose.ui.input.pointer.consume
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 
 /**
  * Screen for confirming seed phrase order via drag and drop.
@@ -86,8 +89,8 @@ fun ConfirmSeedScreen(
             text = "Confirm",
             onClick = {
                 val keypair = JitoService.generateKeypair()
-                scope.launch { seedStorage().savePublicKey(keypair.publicKey.base58()) }
-                backStack.replaceAll(NavKey.WalletHome(keypair.publicKey.base58()))
+                scope.launch { seedStorage().savePublicKey(keypair.publicKey.toBase58()) }
+                backStack.replaceAll(NavKey.WalletHome(keypair.publicKey.toBase58()))
             },
             modifier = Modifier.fillMaxWidth(),
             enabled = items == words


### PR DESCRIPTION
## Summary
- fix SeedStorage implementation for Android DataStore
- update ConfirmSeedScreen imports and use PublicKey.toBase58

## Testing
- `./gradlew assembleDebug -x test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503416a71c833394497f0e0aac3d4a