### PR TITLE
Fix Android build errors

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/bswap/data/SeedStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/bswap/data/SeedStorage.android.kt
@@ -25,9 +25,8 @@ private class AndroidSeedStorage(private val context: Context) : SeedStorage {
         .build()
 
     private fun secretKey(): SecretKey {
-        val keyBytes = ByteArray(32)
-        SecureRandom().nextBytes(keyBytes)
-        return SecretKeySpec(masterKey.alias.toByteArray(), 0, 32, "AES")
+        val keyBytes = MasterKey.DEFAULT_MASTER_KEY_ALIAS.toByteArray()
+        return SecretKeySpec(keyBytes, 0, 32, "AES")
     }
 
     private fun encrypt(data: String): String {

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/ConfirmSeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/ConfirmSeedScreen.kt
@@ -23,7 +23,6 @@ import com.bswap.ui.UiTheme
 import com.bswap.seed.SeedUtils
 import com.bswap.seed.JitoService
 import com.bswap.data.seedStorage
-import org.sol4k.toBase58
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.input.pointer.pointerInput
@@ -31,7 +30,7 @@ import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.launch
-import androidx.compose.ui.input.pointer.consume
+import androidx.compose.ui.input.pointer.util.consume
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue


### PR DESCRIPTION
## Summary
- replace inaccessible MasterKey alias usage
- adjust imports for pointer `consume` extension and remove obsolete Base58 import

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503d2ebd9c8333a1a899adadca1b43