### PR TITLE
Fix seed generation crash

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/bswap/seed/SeedUtils.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/seed/SeedUtils.kt
@@ -9,7 +9,10 @@ object SeedUtils {
         val sha = MessageDigest.getInstance("SHA-256").digest(entropy)
         val bits = entropy + byteArrayOf(sha[0])
         val bitString = bits.joinToString("") { byte ->
-            String.format("%8s", byte.toInt() and 0xFF) .replace(' ', '0')
+            String.format(
+                "%8s",
+                Integer.toBinaryString(byte.toInt() and 0xFF)
+            ).replace(' ', '0')
         }
         val words = mutableListOf<String>()
         for (i in 0 until 12) {


### PR DESCRIPTION
## Summary
- fix binary string creation when generating seed

## Testing
- `./gradlew :composeApp:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850426715008333a046261eafafc4f7