### PR TITLE
Add drag ripple with FilterChip

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/ConfirmSeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/ConfirmSeedScreen.kt
@@ -2,12 +2,15 @@ package com.bswap.ui.seed
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.indication
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -16,9 +19,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import androidx.compose.material3.rememberRipple
 import com.bswap.data.seedStorage
 import com.bswap.navigation.NavKey
 import com.bswap.navigation.replaceAll
@@ -54,23 +59,47 @@ fun ConfirmSeedScreen(
         ) {
             items(items.size) { index ->
                 val word = items[index]
+                val interaction = remember { MutableInteractionSource() }
+                var press: PressInteraction.Press? = null
                 SeedWordChip(
                     word = word,
                     focused = draggingIndex == index,
                     onClick = {},
-                    modifier = Modifier.pointerInput(index) {
-                        detectDragGestures(onDragStart = { draggingIndex = index },
-                            onDragEnd = { draggingIndex = -1 },
-                            onDragCancel = { draggingIndex = -1 }) { change, drag ->
-                            change.consume()
-                            val rowSize = 40f
-                            val newIndex = (index + drag.y / rowSize).toInt().coerceIn(0, items.lastIndex)
-                            if (newIndex != index) {
-                                items.removeAt(index)
-                                items.add(newIndex, word)
+                    interactionSource = interaction,
+                    modifier = Modifier
+                        .graphicsLayer {
+                            val scale = if (draggingIndex == index) 1.1f else 1f
+                            scaleX = scale
+                            scaleY = scale
+                        }
+                        .pointerInput(index) {
+                            detectDragGestures(
+                                onDragStart = { offset ->
+                                    press = PressInteraction.Press(offset)
+                                    interaction.tryEmit(press!!)
+                                    draggingIndex = index
+                                },
+                                onDragEnd = {
+                                    press?.let { interaction.tryEmit(PressInteraction.Release(it)) }
+                                    press = null
+                                    draggingIndex = -1
+                                },
+                                onDragCancel = {
+                                    press?.let { interaction.tryEmit(PressInteraction.Cancel(it)) }
+                                    press = null
+                                    draggingIndex = -1
+                                }
+                            ) { change, drag ->
+                                change.consume()
+                                val rowSize = 40f
+                                val newIndex = (index + drag.y / rowSize).toInt().coerceIn(0, items.lastIndex)
+                                if (newIndex != index) {
+                                    items.removeAt(index)
+                                    items.add(newIndex, word)
+                                }
                             }
                         }
-                    }
+                        .indication(interaction, rememberRipple())
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/SeedWordChip.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/SeedWordChip.kt
@@ -1,14 +1,17 @@
 package com.bswap.ui.seed
 
-import androidx.compose.material3.AssistChip
-import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.foundation.indication
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberRipple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.bswap.ui.UiTheme
 
 /**
@@ -23,16 +26,21 @@ fun SeedWordChip(
     word: String,
     focused: Boolean,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
 ) {
-    val colors = AssistChipDefaults.assistChipColors(
+    val colors = FilterChipDefaults.filterChipColors(
         containerColor = if (focused) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surface,
         labelColor = if (focused) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface
     )
-    AssistChip(
+    FilterChip(
+        selected = focused,
         onClick = onClick,
+        interactionSource = interactionSource,
         label = { Text(word) },
-        modifier = modifier.testTag("SeedWordChip"),
+        modifier = modifier
+            .testTag("SeedWordChip")
+            .indication(interactionSource, rememberRipple()),
         colors = colors
     )
 }


### PR DESCRIPTION
## Summary
- switch SeedWordChip to Material3 FilterChip
- send ripple interactions when SeedWordChip is dragged
- scale dragged chip visually in ConfirmSeedScreen

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68505d41c8848333b615dbf99d5b3407