### PR TITLE
Refactor seed confirmation to chip UI

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -117,8 +117,12 @@ android {
     }
 }
 
+@OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
 dependencies {
     debugImplementation(compose.uiTooling)
+    androidTestImplementation(libs.androidx.test.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(compose.uiTestJUnit4)
 }
 
     compose.desktop {

--- a/composeApp/components.md
+++ b/composeApp/components.md
@@ -11,7 +11,7 @@ The `composeApp` module offers reusable Material components for building wallet 
 - **SeedInputField** – multiline seed phrase text field with validation.
 - **SeedWordChip** – chip displaying single seed word.
 - **GenerateSeedScreen** – screen for showing generated seed phrase.
-- **ConfirmSeedScreen** – drag and drop seed verification screen.
+- **ConfirmSeedScreen** – chip-based seed verification screen.
 - **ImportWalletScreen** – manual seed phrase input screen.
 - **AccountHeader** – avatar with shortened public key and copy action.
 - **AccountSettingsScreen** – basic settings list with export and logout options.

--- a/composeApp/src/androidAndroidTest/kotlin/com/bswap/ui/seed/ConfirmSeedScreenTest.kt
+++ b/composeApp/src/androidAndroidTest/kotlin/com/bswap/ui/seed/ConfirmSeedScreenTest.kt
@@ -1,0 +1,30 @@
+package com.bswap.ui.seed
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import com.bswap.app.MainActivity
+import com.bswap.navigation.rememberBackStack
+import org.junit.Rule
+import org.junit.Test
+
+class ConfirmSeedScreenTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun chipsSpacingAndButtonState() {
+        val seed = listOf("one","two","three")
+        composeTestRule.setContent {
+            ConfirmSeedScreen(seed, rememberBackStack())
+        }
+        composeTestRule.onNodeWithText("Confirm").assertIsNotEnabled()
+        composeTestRule.onAllNodesWithTag("SeedWordChip")[0].performClick()
+        composeTestRule.onAllNodesWithTag("SeedWordChip")[1].performClick()
+        composeTestRule.onAllNodesWithTag("SeedWordChip")[2].performClick()
+        composeTestRule.onNodeWithText("Confirm").assertIsEnabled()
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/bswap/app/interactor/WalletInteractor.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/bswap/app/interactor/WalletInteractor.android.kt
@@ -1,0 +1,29 @@
+package com.bswap.app.interactor
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import com.bswap.app.appContext
+import org.sol4k.Keypair
+
+private const val PREF_NAME = "wallet_prefs"
+private const val KEY_MNEMONIC = "mnemonic"
+
+actual fun walletInteractor(): WalletInteractor = AndroidWalletInteractor(appContext)
+
+private class AndroidWalletInteractor(private val context: Context) : WalletInteractor {
+    override suspend fun createWallet(mnemonic: List<String>): Keypair {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        val prefs = EncryptedSharedPreferences.create(
+            context,
+            PREF_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+        prefs.edit().putString(KEY_MNEMONIC, mnemonic.joinToString(" ")).apply()
+        return Keypair.generate()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/bswap/app/interactor/WalletInteractor.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/app/interactor/WalletInteractor.kt
@@ -1,0 +1,9 @@
+package com.bswap.app.interactor
+
+import org.sol4k.Keypair
+
+interface WalletInteractor {
+    suspend fun createWallet(mnemonic: List<String>): Keypair
+}
+
+expect fun walletInteractor(): WalletInteractor

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/ConfirmSeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/ConfirmSeedScreen.kt
@@ -1,51 +1,41 @@
 package com.bswap.ui.seed
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.indication
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import androidx.compose.material3.rememberRipple
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Text
+import com.bswap.app.interactor.walletInteractor
 import com.bswap.data.seedStorage
 import com.bswap.navigation.NavKey
 import com.bswap.navigation.replaceAll
-import com.bswap.seed.JitoService
-import com.bswap.ui.UiButton
 import kotlinx.coroutines.launch
 
 /**
- * Screen for confirming seed phrase order via drag and drop.
- *
- * @param words shuffled seed words
- * @param backStack navigation back stack
+ * Screen for confirming seed phrase order via chip selection.
  */
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ConfirmSeedScreen(
     words: List<String>,
     backStack: SnapshotStateList<NavKey>,
     modifier: Modifier = Modifier
 ) {
-    val items = remember { mutableStateListOf(*words.shuffled().toTypedArray()) }
-    var draggingIndex by remember { androidx.compose.runtime.mutableIntStateOf(-1) }
+    val available = remember { mutableStateListOf(*words.shuffled().toTypedArray()) }
+    val selected = remember { mutableStateListOf<String>() }
+    val scope = rememberCoroutineScope()
+    val interactor = remember { walletInteractor() }
+
+    val enabled = selected.size == words.size && selected == words
 
     Column(
         modifier = modifier
@@ -53,66 +43,49 @@ fun ConfirmSeedScreen(
             .testTag(NavKey.ConfirmSeed::class.simpleName!!),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        LazyVerticalGrid(
-            columns = GridCells.Fixed(3),
-            modifier = Modifier.weight(1f)
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(3.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)
         ) {
-            items(items.size) { index ->
-                val word = items[index]
-                val interaction = remember { MutableInteractionSource() }
-                var press: PressInteraction.Press? = null
+            selected.forEach { word ->
                 SeedWordChip(
                     word = word,
-                    focused = draggingIndex == index,
+                    selected = true,
                     onClick = {},
-                    interactionSource = interaction,
-                    modifier = Modifier
-                        .graphicsLayer {
-                            val scale = if (draggingIndex == index) 1.1f else 1f
-                            scaleX = scale
-                            scaleY = scale
-                        }
-                        .pointerInput(index) {
-                            detectDragGestures(
-                                onDragStart = { offset ->
-                                    press = PressInteraction.Press(offset)
-                                    interaction.tryEmit(press!!)
-                                    draggingIndex = index
-                                },
-                                onDragEnd = {
-                                    press?.let { interaction.tryEmit(PressInteraction.Release(it)) }
-                                    press = null
-                                    draggingIndex = -1
-                                },
-                                onDragCancel = {
-                                    press?.let { interaction.tryEmit(PressInteraction.Cancel(it)) }
-                                    press = null
-                                    draggingIndex = -1
-                                }
-                            ) { change, drag ->
-                                change.consume()
-                                val rowSize = 40f
-                                val newIndex = (index + drag.y / rowSize).toInt().coerceIn(0, items.lastIndex)
-                                if (newIndex != index) {
-                                    items.removeAt(index)
-                                    items.add(newIndex, word)
-                                }
-                            }
-                        }
-                        .indication(interaction, rememberRipple())
+                    enabled = false
                 )
             }
         }
-        val scope = rememberCoroutineScope()
-        UiButton(
-            text = "Confirm",
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(3.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.weight(1f).fillMaxWidth().padding(horizontal = 16.dp)
+        ) {
+            available.forEach { word ->
+                SeedWordChip(
+                    word = word,
+                    selected = false,
+                    onClick = {
+                        available.remove(word)
+                        selected.add(word)
+                    },
+                    modifier = Modifier,
+                )
+            }
+        }
+        FilledTonalButton(
             onClick = {
-                val keypair = JitoService.generateKeypair()
-                scope.launch { seedStorage().savePublicKey(keypair.publicKey.toBase58()) }
-                backStack.replaceAll(NavKey.WalletHome(keypair.publicKey.toBase58()))
+                scope.launch {
+                    val keypair = interactor.createWallet(selected)
+                    seedStorage().savePublicKey(keypair.publicKey.toBase58())
+                    backStack.replaceAll(NavKey.WalletHome(keypair.publicKey.toBase58()))
+                }
             },
-            modifier = Modifier.fillMaxWidth(),
-            enabled = items == words
-        )
+            enabled = enabled,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Confirm")
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/GenerateSeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/GenerateSeedScreen.kt
@@ -44,7 +44,7 @@ fun GenerateSeedScreen(
     ) {
         LazyColumn(modifier = Modifier.weight(1f)) {
             items(seedWords) { word ->
-                SeedWordChip(word = word, focused = false, onClick = {})
+                SeedWordChip(word = word, selected = false, onClick = {}, enabled = false)
             }
         }
         UiButton(

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/SeedWordChip.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/SeedWordChip.kt
@@ -2,8 +2,8 @@ package com.bswap.ui.seed
 
 import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberRipple
@@ -18,30 +18,30 @@ import com.bswap.ui.UiTheme
  * Single word of a seed phrase represented as a chip.
  *
  * @param word seed word text
- * @param focused whether chip is focused/dragged
+ * @param selected whether chip is part of the selected phrase
  * @param onClick callback on chip press
  */
 @Composable
 fun SeedWordChip(
     word: String,
-    focused: Boolean,
+    selected: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
 ) {
-    val colors = FilterChipDefaults.filterChipColors(
-        containerColor = if (focused) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surface,
-        labelColor = if (focused) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface
+    val border = AssistChipDefaults.assistChipBorder(
+        borderColor = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline
     )
-    FilterChip(
-        selected = focused,
+    AssistChip(
         onClick = onClick,
-        interactionSource = interactionSource,
         label = { Text(word) },
+        enabled = enabled,
+        interactionSource = interactionSource,
+        border = border,
         modifier = modifier
             .testTag("SeedWordChip")
-            .indication(interactionSource, rememberRipple()),
-        colors = colors
+            .indication(interactionSource, rememberRipple())
     )
 }
 
@@ -49,6 +49,6 @@ fun SeedWordChip(
 @Composable
 private fun SeedWordChipPreview() {
     UiTheme {
-        SeedWordChip(word = "solana", focused = false, onClick = {})
+        SeedWordChip(word = "solana", selected = false, onClick = {})
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/bswap/seed/SeedConfirmLogicTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/bswap/seed/SeedConfirmLogicTest.kt
@@ -1,0 +1,24 @@
+package com.bswap.seed
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SeedConfirmLogicTest {
+    @Test
+    fun selected_order_must_match_seed() {
+        val seed = listOf("one","two","three")
+        val selected = mutableListOf<String>()
+        selected += "one"
+        selected += "two"
+        selected += "three"
+        assertTrue(SeedUtils.validateSeed(seed, selected))
+    }
+
+    @Test
+    fun invalid_order_fails_validation() {
+        val seed = listOf("one","two","three")
+        val selected = listOf("two","one","three")
+        assertFalse(SeedUtils.validateSeed(seed, selected))
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/bswap/app/interactor/WalletInteractor.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/bswap/app/interactor/WalletInteractor.desktop.kt
@@ -1,0 +1,9 @@
+package com.bswap.app.interactor
+
+import org.sol4k.Keypair
+
+actual fun walletInteractor(): WalletInteractor = DesktopWalletInteractor
+
+private object DesktopWalletInteractor : WalletInteractor {
+    override suspend fun createWallet(mnemonic: List<String>): Keypair = Keypair.generate()
+}

--- a/composeApp/src/wasmJsMain/kotlin/com/bswap/app/interactor/WalletInteractor.wasm.kt
+++ b/composeApp/src/wasmJsMain/kotlin/com/bswap/app/interactor/WalletInteractor.wasm.kt
@@ -1,0 +1,9 @@
+package com.bswap.app.interactor
+
+import org.sol4k.Keypair
+
+actual fun walletInteractor(): WalletInteractor = WasmWalletInteractor
+
+private object WasmWalletInteractor : WalletInteractor {
+    override suspend fun createWallet(mnemonic: List<String>): Keypair = Keypair.generate()
+}


### PR DESCRIPTION
## Summary
- replace drag/drop seed confirmation with AssistChips in a FlowRow
- add WalletInteractor with EncryptedSharedPreferences on Android
- update SeedWordChip to AssistChip style
- support new chip UI in GenerateSeedScreen
- document component change
- add unit and instrumentation tests

## Testing
- `./gradlew composeApp:allTests` *(fails: SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_685061929f808333b2d7e9a3c381f5cb