### PR TITLE
Refactor seed confirmation UX

### DIFF
--- a/composeApp/src/androidAndroidTest/kotlin/com/bswap/ui/seed/ConfirmSeedScreenTest.kt
+++ b/composeApp/src/androidAndroidTest/kotlin/com/bswap/ui/seed/ConfirmSeedScreenTest.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import com.bswap.app.MainActivity
+import com.bswap.navigation.BswapNavHost
+import com.bswap.navigation.NavKey
 import com.bswap.navigation.rememberBackStack
 import org.junit.Rule
 import org.junit.Test
@@ -19,12 +21,17 @@ class ConfirmSeedScreenTest {
     fun chipsSpacingAndButtonState() {
         val seed = listOf("one","two","three")
         composeTestRule.setContent {
-            ConfirmSeedScreen(seed, rememberBackStack())
+            val backStack = rememberBackStack(NavKey.ConfirmSeed(seed))
+            BswapNavHost(backStack)
         }
         composeTestRule.onNodeWithText("Confirm").assertIsNotEnabled()
         composeTestRule.onAllNodesWithTag("SeedWordChip")[0].performClick()
         composeTestRule.onAllNodesWithTag("SeedWordChip")[1].performClick()
         composeTestRule.onAllNodesWithTag("SeedWordChip")[2].performClick()
         composeTestRule.onNodeWithText("Confirm").assertIsEnabled()
+        composeTestRule.onNodeWithText("Confirm").performClick()
+        composeTestRule.waitUntil(5_000) {
+            composeTestRule.onAllNodesWithTag("WalletHome").fetchSemanticsNodes().isNotEmpty()
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/bswap/app/models/ConfirmSeedViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/app/models/ConfirmSeedViewModel.kt
@@ -1,0 +1,7 @@
+package com.bswap.app.models
+
+import androidx.lifecycle.ViewModel
+
+class ConfirmSeedViewModel : ViewModel() {
+    fun onWordPicked(word: String) { /* placeholder for future analytics */ }
+}

--- a/composeApp/src/commonMain/kotlin/com/bswap/seed/SeedPhraseValidator.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/seed/SeedPhraseValidator.kt
@@ -1,0 +1,7 @@
+package com.bswap.seed
+
+object SeedPhraseValidator {
+    fun isValid(mnemonic: List<String>, selected: List<String>): Boolean {
+        return mnemonic.joinToString(" ") == selected.joinToString(" ")
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/ConfirmSeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/ConfirmSeedScreen.kt
@@ -1,10 +1,25 @@
 package com.bswap.ui.seed
 
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
@@ -13,12 +28,14 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import androidx.compose.material3.FilledTonalButton
-import androidx.compose.material3.Text
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.bswap.app.interactor.walletInteractor
+import com.bswap.app.models.ConfirmSeedViewModel
 import com.bswap.data.seedStorage
 import com.bswap.navigation.NavKey
+import com.bswap.navigation.pop
 import com.bswap.navigation.replaceAll
+import com.bswap.seed.SeedPhraseValidator
 import kotlinx.coroutines.launch
 
 /**
@@ -26,66 +43,93 @@ import kotlinx.coroutines.launch
  */
 @Composable
 fun ConfirmSeedScreen(
-    words: List<String>,
+    mnemonic: List<String>,
     backStack: SnapshotStateList<NavKey>,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    viewModel: ConfirmSeedViewModel = viewModel()
 ) {
-    val available = remember { mutableStateListOf(*words.shuffled().toTypedArray()) }
+    val available = remember { mutableStateListOf(*mnemonic.shuffled().toTypedArray()) }
     val selected = remember { mutableStateListOf<String>() }
     val scope = rememberCoroutineScope()
     val interactor = remember { walletInteractor() }
+    val snackbarHostState = remember { SnackbarHostState() }
 
-    val enabled = selected.size == words.size && selected == words
+    val complete = selected.size == mnemonic.size
 
-    Column(
-        modifier = modifier
-            .padding(16.dp)
-            .testTag(NavKey.ConfirmSeed::class.simpleName!!),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
-    ) {
-        FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(3.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)
-        ) {
-            selected.forEach { word ->
-                SeedWordChip(
-                    word = word,
-                    selected = true,
-                    onClick = {},
-                    enabled = false
-                )
-            }
-        }
-        FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(3.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            modifier = Modifier.weight(1f).fillMaxWidth().padding(horizontal = 16.dp)
-        ) {
-            available.forEach { word ->
-                SeedWordChip(
-                    word = word,
-                    selected = false,
-                    onClick = {
-                        available.remove(word)
-                        selected.add(word)
-                    },
-                    modifier = Modifier,
-                )
-            }
-        }
-        FilledTonalButton(
-            onClick = {
-                scope.launch {
-                    val keypair = interactor.createWallet(selected)
-                    seedStorage().savePublicKey(keypair.publicKey.toBase58())
-                    backStack.replaceAll(NavKey.WalletHome(keypair.publicKey.toBase58()))
+    Scaffold(
+        topBar = {
+            LargeTopAppBar(
+                title = { Text("Confirm your recovery phrase") },
+                navigationIcon = {
+                    IconButton(onClick = { backStack.pop() }) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
                 }
-            },
-            enabled = enabled,
-            modifier = Modifier.fillMaxWidth()
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { padding ->
+        Column(
+            modifier = modifier
+                .padding(padding)
+                .padding(16.dp)
+                .testTag(NavKey.ConfirmSeed::class.simpleName!!),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Text("Confirm")
+            Text(
+                text = "Tap the words in order to confirm your recovery phrase.",
+                style = MaterialTheme.typography.bodyMedium
+            )
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier
+                    .horizontalScroll(rememberScrollState())
+                    .animateContentSize(spring())
+            ) {
+                selected.forEachIndexed { index, word ->
+                    SeedWordChip(
+                        text = "${index + 1}. $word",
+                        onClick = {},
+                        enabled = false
+                    )
+                }
+            }
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier
+                    .horizontalScroll(rememberScrollState())
+                    .animateContentSize(spring())
+                    .weight(1f)
+            ) {
+                available.forEach { word ->
+                    SeedWordChip(
+                        text = word,
+                        onClick = {
+                            available.remove(word)
+                            selected.add(word)
+                            viewModel.onWordPicked(word)
+                        },
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant
+                    )
+                }
+            }
+            FilledTonalButton(
+                onClick = {
+                    scope.launch {
+                        if (!SeedPhraseValidator.isValid(mnemonic, selected)) {
+                            snackbarHostState.showSnackbar("Words do not match")
+                        } else {
+                            val keypair = interactor.createWallet(mnemonic)
+                            seedStorage().savePublicKey(keypair.publicKey.toBase58())
+                            backStack.replaceAll(NavKey.WalletHome(keypair.publicKey.toBase58()))
+                        }
+                    }
+                },
+                enabled = complete,
+                modifier = Modifier.fillMaxWidth()
+            ) { Text("Confirm") }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/GenerateSeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/GenerateSeedScreen.kt
@@ -44,7 +44,7 @@ fun GenerateSeedScreen(
     ) {
         LazyColumn(modifier = Modifier.weight(1f)) {
             items(seedWords) { word ->
-                SeedWordChip(word = word, selected = false, onClick = {}, enabled = false)
+                SeedWordChip(text = word, onClick = {}, enabled = false)
             }
         }
         UiButton(

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/SeedWordChip.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/SeedWordChip.kt
@@ -6,39 +6,43 @@ import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberRipple
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
 import com.bswap.ui.UiTheme
 
 /**
  * Single word of a seed phrase represented as a chip.
  *
- * @param word seed word text
- * @param selected whether chip is part of the selected phrase
- * @param onClick callback on chip press
+ * @param text chip text
+ * @param onClick callback when chip is pressed
  */
 @Composable
 fun SeedWordChip(
-    word: String,
-    selected: Boolean,
+    text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    containerColor: Color = MaterialTheme.colorScheme.surface,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
 ) {
-    val border = AssistChipDefaults.assistChipBorder(
-        borderColor = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline
-    )
     AssistChip(
         onClick = onClick,
-        label = { Text(word) },
+        label = { Text(text, modifier = Modifier.padding(12.dp)) },
         enabled = enabled,
         interactionSource = interactionSource,
-        border = border,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+        shape = RoundedCornerShape(8.dp),
+        colors = AssistChipDefaults.assistChipColors(containerColor = containerColor),
         modifier = modifier
             .testTag("SeedWordChip")
             .indication(interactionSource, rememberRipple())
@@ -49,6 +53,6 @@ fun SeedWordChip(
 @Composable
 private fun SeedWordChipPreview() {
     UiTheme {
-        SeedWordChip(word = "solana", selected = false, onClick = {})
+        SeedWordChip(text = "1. solana", onClick = {})
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/bswap/seed/SeedPhraseValidatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/bswap/seed/SeedPhraseValidatorTest.kt
@@ -1,0 +1,20 @@
+package com.bswap.seed
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SeedPhraseValidatorTest {
+    @Test
+    fun valid_phrase_matches() {
+        val words = listOf("one", "two", "three")
+        assertTrue(SeedPhraseValidator.isValid(words, words))
+    }
+
+    @Test
+    fun invalid_phrase_fails() {
+        val words = listOf("one", "two", "three")
+        val entered = listOf("two", "one", "three")
+        assertFalse(SeedPhraseValidator.isValid(words, entered))
+    }
+}


### PR DESCRIPTION
## Summary
- polish the seed confirmation flow
- style seed word chips
- add view model and validator
- improve Android test

## Testing
- `./gradlew :composeApp:desktopTest` *(fails: Unresolved reference 'tooling')*

------
https://chatgpt.com/codex/tasks/task_e_685065ec26848333975bdb6d5e7c94d6