### PR TITLE
Fix wallet login persistence

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/bswap/app/ComposeApp.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/app/ComposeApp.kt
@@ -1,18 +1,27 @@
 package com.bswap.app
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.bswap.navigation.BswapNavHost
 import com.bswap.navigation.NavKey
 import com.bswap.navigation.rememberBackStack
+import com.bswap.navigation.replaceAll
 import com.bswap.ui.UiTheme
 import androidx.compose.ui.tooling.preview.Preview
+import com.bswap.data.seedStorage
 
 /**
  * Entry composable launching the Bswap navigation flow.
  */
 @Composable
 fun ComposeApp(backStack: SnapshotStateList<NavKey> = rememberBackStack()) {
+    LaunchedEffect(Unit) {
+        val pubKey = seedStorage().loadPublicKey()
+        if (pubKey != null && backStack.firstOrNull() == NavKey.Welcome) {
+            backStack.replaceAll(NavKey.WalletHome(pubKey))
+        }
+    }
     UiTheme {
         BswapNavHost(backStack)
     }

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/wallet/WalletHomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/wallet/WalletHomeScreen.kt
@@ -21,9 +21,11 @@ import com.bswap.ui.token.TokenChip
 import com.bswap.app.networkClient
 import com.bswap.app.api.WalletApi
 import com.bswap.app.models.WalletViewModel
+import com.bswap.navigation.replaceAll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.runtime.collectAsState
+import com.bswap.ui.UiButton
 
 /**
  * Main wallet home screen showing balance and recent transactions.
@@ -62,6 +64,11 @@ fun WalletHomeScreen(
             }
         }
         PrimaryActionBar(onSend = {}, onReceive = {}, onBuy = {}, modifier = Modifier.fillMaxWidth())
+        UiButton(
+            text = "Logout",
+            onClick = { backStack.replaceAll(NavKey.Welcome) },
+            modifier = Modifier.fillMaxWidth()
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- persist loaded wallet after import or creation
- show logout button on wallet home screen
- auto-load saved wallet when app starts

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew build -x test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507851b2348333adc6451e61e59b0f