### PR TITLE
Implement deterministic Solana wallet on Android

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -49,8 +49,8 @@ kotlin {
             implementation(libs.androidx.activity.compose)
             implementation(libs.ktor.client.okhttp)
             implementation(libs.kotlinx.serialization.json)
-            implementation(libs.androidx.datastore.preferences)
             implementation(libs.androidx.security.crypto)
+            implementation(libs.bitcoinj.core)
         }
         commonMain.dependencies {
             implementation(compose.runtime)

--- a/composeApp/src/androidMain/kotlin/com/bswap/app/interactor/WalletInteractor.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/bswap/app/interactor/WalletInteractor.android.kt
@@ -1,29 +1,56 @@
 package com.bswap.app.interactor
 
 import android.content.Context
+import androidx.core.content.edit
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import com.bswap.app.appContext
-import org.sol4k.Keypair
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.bitcoinj.crypto.MnemonicCode
+import org.sol4k.derive.Ed25519HDKeyDerivation
+import org.sol4k.keys.Keypair
+import java.util.Base64
 
 private const val PREF_NAME = "wallet_prefs"
 private const val KEY_MNEMONIC = "mnemonic"
+private const val KEY_SECRET_KEY = "secret_key"
 
 actual fun walletInteractor(): WalletInteractor = AndroidWalletInteractor(appContext)
 
-private class AndroidWalletInteractor(private val context: Context) : WalletInteractor {
-    override suspend fun createWallet(mnemonic: List<String>): Keypair {
+private class AndroidWalletInteractor(
+    private val context: Context
+) : WalletInteractor {
+
+    private val prefs by lazy {
         val masterKey = MasterKey.Builder(context)
             .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
             .build()
-        val prefs = EncryptedSharedPreferences.create(
+
+        EncryptedSharedPreferences.create(
             context,
             PREF_NAME,
             masterKey,
             EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
         )
-        prefs.edit().putString(KEY_MNEMONIC, mnemonic.joinToString(" ")).apply()
-        return Keypair.generate()
     }
+
+    override suspend fun createWallet(mnemonic: List<String>): Keypair =
+        withContext(Dispatchers.Default) {
+            require(mnemonic.size in setOf(12, 15, 18, 21, 24)) {
+                "Mnemonic must have a valid word count"
+            }
+
+            val seed = MnemonicCode.INSTANCE.toSeed(mnemonic, "")
+            val derived = Ed25519HDKeyDerivation.derivePath(intArrayOf(44, 501, 0, 0), seed)
+            val keypair = Keypair.fromSeed(derived.key)
+
+            prefs.edit(commit = true) {
+                putString(KEY_MNEMONIC, mnemonic.joinToString(" "))
+                putString(KEY_SECRET_KEY, Base64.getEncoder().encodeToString(keypair.secretKey))
+            }
+
+            keypair
+        }
 }

--- a/composeApp/src/androidMain/kotlin/com/bswap/data/SeedStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/bswap/data/SeedStorage.android.kt
@@ -1,69 +1,52 @@
 package com.bswap.data
 
 import android.content.Context
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
+import androidx.core.content.edit
+import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import com.bswap.app.appContext
-import kotlinx.coroutines.flow.first
-import java.security.MessageDigest
-import javax.crypto.Cipher
-import javax.crypto.SecretKey
-import javax.crypto.spec.GCMParameterSpec
-import javax.crypto.spec.SecretKeySpec
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
-private val Context.dataStore by preferencesDataStore("seed_store")
+private const val PREF_NAME = "seed_store"
+private const val KEY_SEED = "seed"
+private const val KEY_PUB = "pub_key"
 
 actual fun seedStorage(): SeedStorage = AndroidSeedStorage(appContext)
 
 private class AndroidSeedStorage(private val context: Context) : SeedStorage {
-    private val seedKey = stringPreferencesKey("seed")
-    private val pubKey = stringPreferencesKey("pub_key")
-    private val masterKey = MasterKey.Builder(context)
-        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-        .build()
 
-    private fun secretKey(): SecretKey {
-        val aliasBytes = MasterKey.DEFAULT_MASTER_KEY_ALIAS.toByteArray()
-        val digest = MessageDigest.getInstance("SHA-256").digest(aliasBytes)
-        return SecretKeySpec(digest, "AES")
-    }
+    private val prefs by lazy {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
 
-    private fun encrypt(data: String): String {
-        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
-        val key = secretKey()
-        cipher.init(Cipher.ENCRYPT_MODE, key)
-        val iv = cipher.iv
-        val encrypted = cipher.doFinal(data.toByteArray())
-        return (iv + encrypted).joinToString(separator = ",") { it.toString() }
-    }
-
-    private fun decrypt(data: String): String {
-        val bytes = data.split(',').map { it.toByte() }.toByteArray()
-        val iv = bytes.sliceArray(0 until 12)
-        val enc = bytes.sliceArray(12 until bytes.size)
-        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
-        val key = secretKey()
-        cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(128, iv))
-        return String(cipher.doFinal(enc))
+        EncryptedSharedPreferences.create(
+            context,
+            PREF_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
     }
 
     override suspend fun saveSeed(words: List<String>) {
-        val enc = encrypt(words.joinToString(" "))
-        context.dataStore.edit { it[seedKey] = enc }
+        withContext(Dispatchers.IO) {
+            prefs.edit(commit = true) { putString(KEY_SEED, words.joinToString(" ")) }
+        }
     }
 
-    override suspend fun loadSeed(): List<String>? {
-        val enc = context.dataStore.data.first()[seedKey] ?: return null
-        return decrypt(enc).split(" ")
+    override suspend fun loadSeed(): List<String>? = withContext(Dispatchers.IO) {
+        prefs.getString(KEY_SEED, null)?.split(" ")
     }
 
     override suspend fun savePublicKey(key: String) {
-        context.dataStore.edit { it[pubKey] = key }
+        withContext(Dispatchers.IO) {
+            prefs.edit(commit = true) { putString(KEY_PUB, key) }
+        }
     }
 
-    override suspend fun loadPublicKey(): String? {
-        return context.dataStore.data.first()[pubKey]
+    override suspend fun loadPublicKey(): String? = withContext(Dispatchers.IO) {
+        prefs.getString(KEY_PUB, null)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,8 +21,9 @@ compose-multiplatform = "1.6.10"
 kotlinx-coroutines = "1.9.0"
 coil3 = "3.0.4"
 metaplex = "0.3.0-beta1"
-sol4k = "0.5.4"
+sol4k = "0.5.14"
 kotlinx-datetime = "0.5.0"
+bitcoinj = "0.17"
 androidx-datastore = "1.0.0"
 androidx-security-crypto = "1.1.0-alpha06"
 
@@ -68,6 +69,7 @@ metaplex-solana = { module = "foundation.metaplex:solana", version.ref = "metapl
 metaplex-solana-rpc = { module = "foundation.metaplex:rpc", version.ref = "metaplex" }
 sol4k = { module = "org.sol4k:sol4k", version.ref = "sol4k" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
+bitcoinj-core = { module = "org.bitcoinj:bitcoinj-core", version.ref = "bitcoinj" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidx-security-crypto" }
 


### PR DESCRIPTION
## Summary
- derive Solana keypair from mnemonic instead of generating random key on Android
- persist mnemonic and secret key securely in `EncryptedSharedPreferences`
- update Android seed storage to use encrypted preferences
- add bitcoinj for BIP-39 support and bump sol4k to 0.5.14

## Testing
- `./gradlew test -q` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68508365b96c8333b4307a867da28d03