### PR TITLE
Add history API endpoint and Compose integration

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/bswap/app/api/WalletApi.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/app/api/WalletApi.kt
@@ -24,6 +24,9 @@ class WalletApi(private val client: HttpClient) {
     suspend fun getTokens(address: String): List<TokenInfo> =
         client.get("$baseUrl/wallet/$address/tokens").body()
 
+    suspend fun getHistory(address: String): List<SolanaTx> =
+        client.get("$baseUrl/wallet/$address/history").body()
+
     suspend fun swap(request: SwapRequest): SwapTx =
         client.post("$baseUrl/swap") {
             contentType(ContentType.Application.Json)

--- a/composeApp/src/commonMain/kotlin/com/bswap/app/models/WalletViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/app/models/WalletViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bswap.app.api.WalletApi
 import com.bswap.shared.model.WalletInfo
+import com.bswap.shared.model.SolanaTx
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -16,6 +17,9 @@ class WalletViewModel(
     private val _walletInfo = MutableStateFlow<WalletInfo?>(null)
     val walletInfo: StateFlow<WalletInfo?> = _walletInfo
 
+    private val _history = MutableStateFlow<List<SolanaTx>>(emptyList())
+    val history: StateFlow<List<SolanaTx>> = _history
+
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading
 
@@ -27,6 +31,9 @@ class WalletViewModel(
         _isLoading.value = true
         runCatching { api.walletInfo(address) }
             .onSuccess { _walletInfo.value = it }
+            .onFailure { it.printStackTrace() }
+        runCatching { api.getHistory(address) }
+            .onSuccess { _history.value = it }
             .onFailure { it.printStackTrace() }
         _isLoading.value = false
     }

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/tx/TransactionRow.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/tx/TransactionRow.kt
@@ -14,14 +14,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bswap.ui.UiTheme
-
-/** Data class representing a Solana transaction. */
-data class SolanaTx(
-    val signature: String,
-    val address: String,
-    val amount: Double,
-    val incoming: Boolean
-)
+import com.bswap.shared.model.SolanaTx
 
 /**
  * Row displaying brief information about a transaction.

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/wallet/WalletHomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/wallet/WalletHomeScreen.kt
@@ -21,6 +21,7 @@ import com.bswap.ui.token.TokenChip
 import com.bswap.app.networkClient
 import com.bswap.app.api.WalletApi
 import com.bswap.app.models.WalletViewModel
+import com.bswap.ui.tx.TransactionRow
 import com.bswap.navigation.replaceAll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
@@ -42,6 +43,7 @@ fun WalletHomeScreen(
 
     val walletInfo by viewModel.walletInfo.collectAsState()
     val loading by viewModel.isLoading.collectAsState()
+    val history by viewModel.history.collectAsState()
 
     val solBalanceText = walletInfo?.lamports?.let { "${it / 1_000_000_000.0} SOL" } ?: "0 SOL"
     val tokens = walletInfo?.tokens ?: emptyList()
@@ -61,6 +63,9 @@ fun WalletHomeScreen(
                     balance = token.amount ?: "0",
                     onClick = {}
                 )
+            }
+            items(history) { tx ->
+                TransactionRow(tx = tx)
             }
         }
         PrimaryActionBar(onSend = {}, onReceive = {}, onBuy = {}, modifier = Modifier.fillMaxWidth())

--- a/server/src/main/kotlin/com/bswap/server/routes/Routes.kt
+++ b/server/src/main/kotlin/com/bswap/server/routes/Routes.kt
@@ -34,6 +34,16 @@ fun Route.walletRoutes(service: WalletService) {
             .onFailure { call.respond(HttpStatusCode.InternalServerError, ApiError(it.message ?: "error")) }
     }
 
+    get("/wallet/{address}/history") {
+        val address = call.parameters["address"] ?: return@get call.respond(
+            HttpStatusCode.BadRequest,
+            ApiError("missing address")
+        )
+        val result = service.getHistory(address)
+        result.onSuccess { call.respond(it) }
+            .onFailure { call.respond(HttpStatusCode.InternalServerError, ApiError(it.message ?: "error")) }
+    }
+
     get("/tokens/search") {
         val q = call.request.queryParameters["q"] ?: return@get call.respond(
             HttpStatusCode.BadRequest,

--- a/server/src/main/kotlin/com/bswap/server/service/WalletService.kt
+++ b/server/src/main/kotlin/com/bswap/server/service/WalletService.kt
@@ -33,6 +33,12 @@ class WalletService(
         Result.failure(e)
     }
 
+    suspend fun getHistory(address: String): Result<List<SolanaTx>> = try {
+        Result.success(rpcClient.getHistory(address))
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
     suspend fun walletInfo(address: String): Result<WalletInfo> = try {
         val balance = rpcClient.getBalance(address)
         val tokens = rpcClient.getSPLTokens(address)

--- a/shared/src/commonMain/kotlin/com/bswap/shared/model/History.kt
+++ b/shared/src/commonMain/kotlin/com/bswap/shared/model/History.kt
@@ -1,0 +1,11 @@
+package com.bswap.shared.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SolanaTx(
+    val signature: String,
+    val address: String,
+    val amount: Double = 0.0,
+    val incoming: Boolean = true,
+)


### PR DESCRIPTION
## Summary
- add `SolanaTx` model for transactions
- implement history retrieval in `SolanaRpcClient`
- expose `/wallet/{address}/history` route
- use history endpoint in `WalletApi` and `WalletViewModel`
- display transactions in `WalletHomeScreen`
- update `TransactionRow` to use shared model

## Testing
- `./gradlew :server:test :shared:test` *(fails: missing Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68509e7f4ab48333b42dacbbd681ecb3