### PR TITLE
Fix protobuf classpath conflicts

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -50,7 +50,9 @@ kotlin {
             implementation(libs.ktor.client.okhttp)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.androidx.security.crypto)
-            implementation(libs.bitcoinj.core)
+            implementation("org.bitcoinj:bitcoinj-core:${libs.versions.bitcoinj.get()}") {
+                exclude(group = "com.google.protobuf", module = "protobuf-javalite")
+            }
             implementation(libs.wallet.core)
         }
         commonMain.dependencies {


### PR DESCRIPTION
## Summary
- exclude protobuf-javalite from bitcoinj dependency to avoid duplicate class errors

## Testing
- `./gradlew :composeApp:assembleDebug --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851f85ffbe883338ef9089eb437ff98