### PR TITLE
Fix wallet import crash on Android

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/bswap/app/Application.kt
+++ b/composeApp/src/androidMain/kotlin/com/bswap/app/Application.kt
@@ -6,5 +6,8 @@ class Application : Application() {
     override fun onCreate() {
         super.onCreate()
         initializeAppContext(this)
+        // Ensure native libraries from wallet-core are available before any
+        // wallet APIs are used.
+        System.loadLibrary("TrustWalletCore")
     }
 }


### PR DESCRIPTION
## Summary
- load the Trust Wallet Core native library during Application startup

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851faf83a448333b28caa97892b3e88