### PR TITLE
Remove design system, add triangle background

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,15 @@
+# Migration Guide
+
+This release removes the `BswapTheme` file introduced earlier. All components
+continue to use `UiTheme` which now defines shapes and colours directly.
+
+## Updating Buttons
+
+`UiButton` now renders a FilledTonal or Outlined style depending on the
+`secondary` parameter. Ensure custom buttons pass `secondary = true` when a
+secondary action is required.
+
+## Onboarding Flow
+
+The welcome screen now presents a swipeable carousel with "Create Wallet" and
+"Import Wallet" actions. Navigation keys remain unchanged.

--- a/composeApp/README.md
+++ b/composeApp/README.md
@@ -1,6 +1,6 @@
 # Compose UI Components
 
-The `composeApp` module provides a small library of Jetpack Compose widgets styled with `UiTheme`. Components automatically adapt to light or dark backgrounds.
+The `composeApp` module provides a small library of Jetpack Compose widgets styled with `UiTheme`. Components automatically adapt to light or dark backgrounds without an additional design system.
 
 ## Available Components
 

--- a/composeApp/src/androidAndroidTest/kotlin/com/bswap/ui/onboarding/OnboardingWelcomeScreenTest.kt
+++ b/composeApp/src/androidAndroidTest/kotlin/com/bswap/ui/onboarding/OnboardingWelcomeScreenTest.kt
@@ -1,0 +1,26 @@
+package com.bswap.ui.onboarding
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.bswap.app.MainActivity
+import com.bswap.navigation.BswapNavHost
+import com.bswap.navigation.NavKey
+import com.bswap.navigation.rememberBackStack
+import org.junit.Rule
+import org.junit.Test
+
+class OnboardingWelcomeScreenTest {
+    @get:Rule
+    val rule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun buttonsNavigate() {
+        rule.setContent {
+            val backStack = rememberBackStack(NavKey.Welcome)
+            BswapNavHost(backStack)
+        }
+        rule.onNodeWithText("Create Wallet").performClick()
+        rule.waitUntil { rule.onNodeWithText("Next").fetchSemanticsNodes().isNotEmpty() }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/TrianglesBackground.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/TrianglesBackground.kt
@@ -1,0 +1,38 @@
+package com.bswap.ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+
+/**
+ * Simple sci-fi style background drawing a set of triangles in light grey.
+ */
+@Composable
+fun TrianglesBackground(modifier: Modifier = Modifier) {
+    Canvas(modifier) {
+        drawTriangles()
+    }
+}
+
+private fun DrawScope.drawTriangles() {
+    val sizeStep = size.minDimension / 4f
+    val light = Color.LightGray.copy(alpha = 0.2f)
+    for (row in 0..3) {
+        for (col in 0..3) {
+            if ((row + col) % 2 == 0) {
+                val x = col * sizeStep
+                val y = row * sizeStep
+                val path = Path().apply {
+                    moveTo(x, y)
+                    lineTo(x + sizeStep, y)
+                    lineTo(x + sizeStep / 2f, y + sizeStep)
+                    close()
+                }
+                drawPath(path, light)
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/UiButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/UiButton.kt
@@ -1,9 +1,15 @@
 package com.bswap.ui
 
-import androidx.compose.material3.Button
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
@@ -11,14 +17,19 @@ fun UiButton(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    enabled: Boolean = true
+    enabled: Boolean = true,
+    secondary: Boolean = false
 ) {
-    Button(
-        onClick = onClick,
-        modifier = modifier,
-        enabled = enabled
-    ) {
-        Text(text)
+    val shape = RoundedCornerShape(12.dp)
+    val m = modifier.defaultMinSize(minWidth = 48.dp, minHeight = 48.dp)
+    if (secondary) {
+        OutlinedButton(onClick = onClick, enabled = enabled, shape = shape, modifier = m) {
+            Text(text)
+        }
+    } else {
+        FilledTonalButton(onClick = onClick, enabled = enabled, shape = shape, modifier = m) {
+            Text(text)
+        }
     }
 }
 
@@ -26,7 +37,12 @@ fun UiButton(
 @Composable
 fun UiButtonPreview() {
     UiTheme {
-        UiButton(text = "Button", onClick = {})
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            UiButton(text = "Primary", onClick = {})
+            UiButton(text = "Secondary", onClick = {}, secondary = true)
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/UiTheme.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/UiTheme.kt
@@ -2,13 +2,16 @@ package com.bswap.ui
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Typography
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Shapes
+import androidx.compose.material3.Typography
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.unit.dp
+
 
 private val DarkColorPalette = darkColorScheme(
     primary = Color.White,
@@ -53,7 +56,11 @@ fun UiTheme(
     MaterialTheme(
         colorScheme = colors,
         typography = Typography(),
-        shapes = Shapes(),
+        shapes = Shapes(
+            small = RoundedCornerShape(8.dp),
+            medium = RoundedCornerShape(12.dp),
+            large = RoundedCornerShape(28.dp)
+        ),
         content = content
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/onboarding/OnboardingWelcomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/onboarding/OnboardingWelcomeScreen.kt
@@ -1,51 +1,64 @@
 package com.bswap.ui.onboarding
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.bswap.ui.TrianglesBackground
 import androidx.compose.ui.platform.testTag
-import com.bswap.navigation.NavKey
-import com.bswap.navigation.rememberBackStack
-import androidx.compose.runtime.snapshots.SnapshotStateList
-import com.bswap.navigation.push
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.bswap.navigation.NavKey
+import com.bswap.navigation.push
 import com.bswap.ui.UiButton
-import com.bswap.ui.UiTheme
 
-/**
- * First onboarding screen with a welcome message and start button.
- *
- * @param backStack navigation back stack
- */
+private data class Slide(val title: String)
+
+private val slides = listOf(
+    Slide("Trade SPL tokens easily"),
+    Slide("Secure your funds"),
+    Slide("Open source wallet")
+)
+
 @Composable
 fun OnboardingWelcomeScreen(
     backStack: SnapshotStateList<NavKey>,
     modifier: Modifier = Modifier
 ) {
+    val pagerState = rememberPagerState(pageCount = { slides.size })
     Column(
         modifier = modifier
-            .padding(16.dp)
-            .fillMaxWidth()
-            .testTag(NavKey.Welcome::class.simpleName!!),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
+            .fillMaxSize()
+            .testTag(NavKey.Welcome::class.simpleName!!)
     ) {
-        Text("Welcome to Bswap", style = MaterialTheme.typography.headlineMedium)
-        UiButton(text = "\u041d\u0430\u0447\u0430\u0442\u044c", onClick = { backStack.push(NavKey.ChoosePath) }, modifier = Modifier.fillMaxWidth())
-    }
-}
-
-@Preview
-@Composable
-private fun OnboardingWelcomeScreenPreview() {
-    UiTheme {
-        OnboardingWelcomeScreen(rememberBackStack())
+        HorizontalPager(state = pagerState, modifier = Modifier.weight(1f)) { page ->
+            val slide = slides[page]
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                TrianglesBackground(modifier = Modifier.matchParentSize())
+                Text(slide.title, style = MaterialTheme.typography.headlineMedium)
+            }
+        }
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            UiButton(text = "Create Wallet", onClick = { backStack.push(NavKey.GenerateSeed) }, modifier = Modifier.weight(1f))
+            UiButton(text = "Import Wallet", onClick = { backStack.push(NavKey.ImportWallet) }, secondary = true, modifier = Modifier.weight(1f))
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/ConfirmSeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/ConfirmSeedScreen.kt
@@ -14,7 +14,8 @@ import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -26,6 +27,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -56,13 +59,23 @@ fun ConfirmSeedScreen(
 
     Scaffold(
         topBar = {
-            LargeTopAppBar(
-                title = { Text("Confirm your recovery phrase") },
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        "Confirm your recovery phrase",
+                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold)
+                    )
+                },
                 navigationIcon = {
                     IconButton(onClick = { backStack.pop() }) {
                         Icon(Icons.Default.ArrowBack, contentDescription = "Back")
                     }
-                }
+                },
+                modifier = Modifier.padding(horizontal = 24.dp),
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = Color.Transparent
+                ),
+                scrollBehavior = null
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) }

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/GenerateSeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/GenerateSeedScreen.kt
@@ -4,15 +4,25 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import com.bswap.navigation.NavKey
 import com.bswap.navigation.rememberBackStack
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.bswap.navigation.push
@@ -23,6 +33,8 @@ import com.bswap.ui.UiTheme
 import com.bswap.app.copyToClipboard
 import com.bswap.seed.SeedUtils
 import com.bswap.data.seedStorage
+import androidx.compose.ui.Alignment
+import androidx.compose.foundation.shape.RoundedCornerShape
 
 /**
  * Screen displaying generated seed phrase.
@@ -36,22 +48,45 @@ fun GenerateSeedScreen(
 ) {
     val seedWords = remember { SeedUtils.generateSeed() }
     LaunchedEffect(Unit) { seedStorage().saveSeed(seedWords) }
+    var useBiometrics by remember { mutableStateOf(false) }
     Column(
         modifier = modifier
             .padding(16.dp)
             .testTag(NavKey.GenerateSeed::class.simpleName!!),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        LazyColumn(modifier = Modifier.weight(1f)) {
-            items(seedWords) { word ->
-                SeedWordChip(text = word, onClick = {}, enabled = false)
+        Box(modifier = Modifier.weight(1f)) {
+            Card(
+                shape = RoundedCornerShape(28.dp),
+                elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.padding(16.dp)
+                ) {
+                    seedWords.forEachIndexed { index, word ->
+                        SeedWordChip(text = "${index + 1}. $word", onClick = {}, enabled = false)
+                    }
+                }
+            }
+            FloatingActionButton(
+                onClick = { copyToClipboard(seedWords.joinToString(" ")) },
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+            ) {
+                Icon(Icons.Default.ContentCopy, contentDescription = "Copy")
             }
         }
-        UiButton(
-            text = "Copy",
-            onClick = { copyToClipboard(seedWords.joinToString(" ")) },
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier.fillMaxWidth()
-        )
+        ) {
+            Text("Enable biometrics")
+            Switch(checked = useBiometrics, onCheckedChange = { useBiometrics = it })
+        }
         UiButton(text = "Next", onClick = { backStack.push(NavKey.ConfirmSeed(seedWords)) }, modifier = Modifier.fillMaxWidth())
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/wallet/WalletHomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/wallet/WalletHomeScreen.kt
@@ -1,6 +1,7 @@
 package com.bswap.ui.wallet
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -26,6 +27,10 @@ import com.bswap.navigation.replaceAll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.runtime.collectAsState
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.ui.Alignment
 import com.bswap.ui.UiButton
 
 /**
@@ -47,33 +52,43 @@ fun WalletHomeScreen(
 
     val solBalanceText = walletInfo?.lamports?.let { "${it / 1_000_000_000.0} SOL" } ?: "0 SOL"
     val tokens = walletInfo?.tokens ?: emptyList()
-    Column(
-        modifier = modifier
-            .padding(16.dp)
-            .fillMaxWidth()
-            .testTag(NavKey.WalletHome::class.simpleName!!),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
-    ) {
-        BalanceCard(solBalance = solBalanceText, tokensValue = "$0", isLoading = loading)
-        LazyColumn(modifier = Modifier.weight(1f)) {
-            items(tokens) { token ->
-                TokenChip(
-                    icon = Icons.Default.Star,
-                    ticker = token.symbol ?: token.mint.take(4),
-                    balance = token.amount ?: "0",
-                    onClick = {}
-                )
+    Box(modifier = modifier.testTag(NavKey.WalletHome::class.simpleName!!)) {
+        Column(
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            BalanceCard(solBalance = solBalanceText, tokensValue = "$0", isLoading = loading)
+            LazyColumn(modifier = Modifier.weight(1f)) {
+                items(tokens) { token ->
+                    TokenChip(
+                        icon = Icons.Default.Star,
+                        ticker = token.symbol ?: token.mint.take(4),
+                        balance = token.amount ?: "0",
+                        onClick = {}
+                    )
+                }
+                items(history) { tx ->
+                    TransactionRow(tx = tx)
+                }
             }
-            items(history) { tx ->
-                TransactionRow(tx = tx)
-            }
+            PrimaryActionBar(onSend = {}, onReceive = {}, onBuy = {}, modifier = Modifier.fillMaxWidth())
+            UiButton(
+                text = "Logout",
+                onClick = { backStack.replaceAll(NavKey.Welcome) },
+                modifier = Modifier.fillMaxWidth(),
+                secondary = true
+            )
         }
-        PrimaryActionBar(onSend = {}, onReceive = {}, onBuy = {}, modifier = Modifier.fillMaxWidth())
-        UiButton(
-            text = "Logout",
-            onClick = { backStack.replaceAll(NavKey.Welcome) },
-            modifier = Modifier.fillMaxWidth()
-        )
+        FloatingActionButton(
+            onClick = {},
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp)
+        ) {
+            Icon(Icons.Default.Add, contentDescription = null)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- drop obsolete `BswapTheme`
- define shapes directly in `UiTheme`
- add `TrianglesBackground` composable
- show sci‑fi triangles in onboarding carousel
- update docs and migration notes

## Testing
- `./gradlew --no-daemon assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854aa6e11d083339a178c73fd6fcce1