### PR TITLE
Add basic Home and Settings screens

### DIFF
--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -1,3 +1,16 @@
 <resources>
     <string name="app_name">Bswap</string>
+    <string name="home">Home</string>
+    <string name="settings">Settings</string>
+    <string name="buy">Buy</string>
+    <string name="send">Send</string>
+    <string name="receive">Receive</string>
+    <string name="swap">Swap</string>
+    <string name="public_key">Public Key</string>
+    <string name="copy">Copy</string>
+    <string name="back">Back</string>
+    <string name="logout">Logout</string>
+    <string name="dark_theme">Dark Theme</string>
+    <string name="language">Language</string>
+    <string name="privacy_policy">Privacy Policy</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/bswap/app/Strings.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/app/Strings.kt
@@ -1,0 +1,19 @@
+package com.bswap.app
+
+object Strings {
+    const val home = "Home"
+    const val settings = "Settings"
+    const val buy = "Buy"
+    const val send = "Send"
+    const val receive = "Receive"
+    const val swap = "Swap"
+    const val public_key = "Public Key"
+    const val copy = "Copy"
+    const val back = "Back"
+    const val portfolio_total = "Portfolio"
+    const val logout = "Logout"
+    const val light_theme = "Light Theme"
+    const val dark_theme = "Dark Theme"
+    const val language = "Language"
+    const val privacy_policy = "Privacy Policy"
+}

--- a/composeApp/src/commonMain/kotlin/com/bswap/navigation/BswapNavHost.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/navigation/BswapNavHost.kt
@@ -3,13 +3,13 @@ package com.bswap.navigation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.bswap.navigation.NavDisplay
-import com.bswap.ui.account.AccountSettingsScreen
+import com.bswap.ui.settings.SettingsScreen
 import com.bswap.ui.onboarding.ChoosePathScreen
 import com.bswap.ui.onboarding.OnboardingWelcomeScreen
 import com.bswap.ui.seed.ConfirmSeedScreen
 import com.bswap.ui.seed.GenerateSeedScreen
 import com.bswap.ui.wallet.ImportWalletScreen
-import com.bswap.ui.wallet.WalletHomeScreen
+import com.bswap.ui.home.HomeScreen
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 
@@ -22,8 +22,15 @@ fun BswapNavHost(backStack: SnapshotStateList<NavKey>) {
             NavKey.GenerateSeed -> GenerateSeedScreen(backStack)
             is NavKey.ConfirmSeed -> ConfirmSeedScreen(key.words, backStack)
             NavKey.ImportWallet -> ImportWalletScreen(backStack)
-            is NavKey.WalletHome -> WalletHomeScreen(key.publicKey, backStack)
-            NavKey.AccountSettings -> AccountSettingsScreen(backStack)
+            is NavKey.WalletHome -> HomeScreen(
+                publicKey = key.publicKey,
+                onSettings = { backStack.push(NavKey.AccountSettings(key.publicKey)) }
+            )
+            is NavKey.AccountSettings -> SettingsScreen(
+                publicKey = key.publicKey,
+                onBack = { backStack.pop() },
+                onLogout = { backStack.replaceAll(NavKey.Welcome) }
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/bswap/navigation/NavKey.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/navigation/NavKey.kt
@@ -11,5 +11,5 @@ sealed interface NavKey {
     @Serializable data class ConfirmSeed(val words: List<String>) : NavKey
     @Serializable object ImportWallet : NavKey
     @Serializable data class WalletHome(val publicKey: String) : NavKey
-    @Serializable object AccountSettings : NavKey
+    @Serializable data class AccountSettings(val publicKey: String) : NavKey
 }

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/home/HomeScreen.kt
@@ -1,0 +1,186 @@
+package com.bswap.ui.home
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material.icons.filled.SwapHoriz
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.ViewModelProvider
+import com.bswap.app.Strings
+import com.bswap.app.networkClient
+import com.bswap.app.api.WalletApi
+import com.bswap.app.models.WalletViewModel
+import com.bswap.ui.TrianglesBackground
+import com.bswap.ui.account.AccountHeader
+import com.bswap.ui.balance.BalanceCard
+import com.bswap.ui.token.TokenChip
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/** Simple fake asset model */
+data class Asset(
+    val symbol: String,
+    val balance: String,
+)
+
+/** UI state for HomeScreen */
+data class HomeUiState(
+    val portfolio: String = "$0",
+    val assets: List<Asset> = emptyList(),
+)
+
+class HomeViewModel(
+    private val api: WalletApi,
+    private val address: String,
+) : androidx.lifecycle.ViewModel() {
+    private val _uiState = MutableStateFlow(HomeUiState())
+    val uiState: StateFlow<HomeUiState> = _uiState
+
+    init {
+        viewModelScope.launch {
+            refresh()
+        }
+    }
+
+    fun refresh() = viewModelScope.launch {
+        runCatching { api.walletInfo(address) }
+            .onSuccess { info ->
+                val assets = info.tokens.map { Asset(it.symbol ?: it.mint, it.amount ?: "0") }
+                _uiState.value = HomeUiState(portfolio = "${'$'}${info.lamports / 1_000_000_000.0}", assets = assets)
+            }
+    }
+}
+
+@Composable
+fun HomeScreen(publicKey: String, onSettings: () -> Unit, modifier: Modifier = Modifier) {
+    val client = remember { networkClient() }
+    val api = remember(client) { WalletApi(client) }
+    val vm: HomeViewModel = viewModel(factory = object : androidx.lifecycle.ViewModelProvider.Factory {
+        override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
+            @Suppress("UNCHECKED_CAST")
+            return HomeViewModel(api, publicKey) as T
+        }
+    })
+    val state by vm.uiState.collectAsState()
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(Strings.home) },
+                actions = {
+                    IconButton(onClick = onSettings) {
+                        Icon(Icons.Default.Settings, contentDescription = Strings.settings)
+                    }
+                }
+            )
+        },
+        bottomBar = {
+            NavigationBar {
+                NavigationBarItem(
+                    selected = true,
+                    onClick = {},
+                    icon = { Icon(Icons.Default.ArrowUpward, contentDescription = Strings.home) },
+                    label = { Text(Strings.home) }
+                )
+                NavigationBarItem(
+                    selected = false,
+                    onClick = onSettings,
+                    icon = { Icon(Icons.Default.Settings, contentDescription = Strings.settings) },
+                    label = { Text(Strings.settings) }
+                )
+            }
+        },
+        modifier = modifier.fillMaxSize()
+    ) { inner ->
+        Box(
+            modifier = Modifier
+                .padding(inner)
+                .fillMaxSize()
+        ) {
+            TrianglesBackground(modifier = Modifier.matchParentSize())
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                AccountHeader(publicKey = publicKey, onCopy = {})
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    elevation = CardDefaults.cardElevation(4.dp)
+                ) {
+                    Column(Modifier.padding(16.dp)) {
+                        Text(text = state.portfolio, style = MaterialTheme.typography.headlineSmall)
+                    }
+                }
+                LazyColumn(modifier = Modifier.weight(1f)) {
+                    items(state.assets) { asset ->
+                        TokenChip(
+                            icon = Icons.Default.Star,
+                            ticker = asset.symbol,
+                            balance = asset.balance,
+                            onClick = {}
+                        )
+                    }
+                }
+                ActionRow()
+            }
+        }
+    }
+}
+
+@Composable
+fun ActionRow(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        FilledTonalButton(onClick = {}, modifier = Modifier.fillMaxWidth()) {
+            Icon(Icons.Default.ShoppingCart, contentDescription = Strings.buy)
+            Text(Strings.buy)
+        }
+        FilledTonalButton(onClick = {}, modifier = Modifier.fillMaxWidth()) {
+            Icon(Icons.Default.ArrowUpward, contentDescription = Strings.send)
+            Text(Strings.send)
+        }
+        FilledTonalButton(onClick = {}, modifier = Modifier.fillMaxWidth()) {
+            Icon(Icons.Default.ArrowDownward, contentDescription = Strings.receive)
+            Text(Strings.receive)
+        }
+        FilledTonalButton(onClick = {}, modifier = Modifier.fillMaxWidth()) {
+            Icon(Icons.Default.SwapHoriz, contentDescription = Strings.swap)
+            Text(Strings.swap)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/settings/SettingsScreen.kt
@@ -1,0 +1,103 @@
+package com.bswap.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Divider
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import androidx.compose.foundation.clickable
+import com.bswap.app.Strings
+import com.bswap.ui.account.AccountHeader
+import com.bswap.ui.UiSwitch
+import com.bswap.app.openLink
+import com.bswap.app.copyToClipboard
+import com.bswap.ui.UiButton
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SettingsScreen(publicKey: String, onBack: () -> Unit, onLogout: () -> Unit, modifier: Modifier = Modifier) {
+    val darkTheme = remember { mutableStateOf(false) }
+    val languages = listOf("en", "uk", "ru")
+    val expanded = remember { mutableStateOf(false) }
+    val language = remember { mutableStateOf(languages.first()) }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = Strings.back)
+                    }
+                },
+                title = { Text(Strings.settings) }
+            )
+        }
+    ) { inner ->
+        Column(
+            modifier = modifier
+                .padding(inner)
+                .fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            AccountHeader(publicKey = publicKey, onCopy = {})
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(Strings.dark_theme)
+                UiSwitch(checked = darkTheme.value, onCheckedChange = { darkTheme.value = it })
+            }
+            Divider()
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .clickable { expanded.value = true },
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(Strings.language)
+                Text(language.value)
+            }
+            DropdownMenu(expanded = expanded.value, onDismissRequest = { expanded.value = false }) {
+                languages.forEach {
+                    DropdownMenuItem(text = { Text(it) }, onClick = {
+                        language.value = it
+                        expanded.value = false
+                    })
+                }
+            }
+            ListItem(
+                headlineContent = { Text(Strings.privacy_policy) },
+                modifier = Modifier.clickable { openLink("https://example.com/privacy") }
+            )
+            FilledTonalButton(onClick = onLogout, modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)) {
+                Text(Strings.logout)
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- introduce HomeScreen with fake portfolio data and quick actions
- add SettingsScreen stub
- hook screens into BswapNavHost navigation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685732c745308333af4c2e47fb7b7a1b