### PR TITLE
Fix HDWallet key derivation

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/bswap/wallet/Bip44WalletDerivationStrategy.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/wallet/Bip44WalletDerivationStrategy.kt
@@ -3,12 +3,13 @@ package com.bswap.wallet
 import com.bswap.seed.MnemonicValidator
 import com.bswap.shared.wallet.Keypair
 import wallet.core.jni.HDWallet
+import wallet.core.jni.CoinType
 
 class Bip44WalletDerivationStrategy : WalletDerivationStrategy {
     override fun deriveKeypair(mnemonic: List<String>, accountIndex: Int, passphrase: String): Keypair {
         require(MnemonicValidator.isValidMnemonic(mnemonic)) { "Invalid BIP-39 mnemonic" }
         val wallet = HDWallet(mnemonic.joinToString(" "), passphrase)
-        val privateKey = wallet.getKey("m/44'/501'/${accountIndex}'/0'")
+        val privateKey = wallet.getKey(CoinType.SOLANA, "m/44'/501'/${accountIndex}'/0'")
         val publicKey = privateKey.getPublicKeyEd25519()
         return Keypair(publicKey.data(), privateKey.data())
     }


### PR DESCRIPTION
## Summary
- ensure correct HDWallet.getKey usage with CoinType

## Testing
- `./gradlew :composeApp:compileDebugKotlinAndroid --stacktrace -q` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685738d180fc8333af5595faaa1d3247