### PR TITLE
Add transaction history screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/bswap/app/Strings.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/app/Strings.kt
@@ -7,6 +7,7 @@ object Strings {
     const val send = "Send"
     const val receive = "Receive"
     const val swap = "Swap"
+    const val history = "History"
     const val public_key = "Public Key"
     const val copy = "Copy"
     const val back = "Back"

--- a/composeApp/src/commonMain/kotlin/com/bswap/navigation/BswapNavHost.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/navigation/BswapNavHost.kt
@@ -10,6 +10,7 @@ import com.bswap.ui.seed.ConfirmSeedScreen
 import com.bswap.ui.seed.GenerateSeedScreen
 import com.bswap.ui.wallet.ImportWalletScreen
 import com.bswap.ui.home.HomeScreen
+import com.bswap.ui.history.TransactionHistoryScreen
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 
@@ -24,12 +25,17 @@ fun BswapNavHost(backStack: SnapshotStateList<NavKey>) {
             NavKey.ImportWallet -> ImportWalletScreen(backStack)
             is NavKey.WalletHome -> HomeScreen(
                 publicKey = key.publicKey,
-                onSettings = { backStack.push(NavKey.AccountSettings(key.publicKey)) }
+                onSettings = { backStack.push(NavKey.AccountSettings(key.publicKey)) },
+                onHistory = { backStack.push(NavKey.TransactionHistory(key.publicKey)) }
             )
             is NavKey.AccountSettings -> SettingsScreen(
                 publicKey = key.publicKey,
                 onBack = { backStack.pop() },
                 onLogout = { backStack.replaceAll(NavKey.Welcome) }
+            )
+            is NavKey.TransactionHistory -> TransactionHistoryScreen(
+                publicKey = key.publicKey,
+                onBack = { backStack.pop() }
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/bswap/navigation/NavKey.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/navigation/NavKey.kt
@@ -12,4 +12,5 @@ sealed interface NavKey {
     @Serializable object ImportWallet : NavKey
     @Serializable data class WalletHome(val publicKey: String) : NavKey
     @Serializable data class AccountSettings(val publicKey: String) : NavKey
+    @Serializable data class TransactionHistory(val publicKey: String) : NavKey
 }

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/history/TransactionHistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/history/TransactionHistoryScreen.kt
@@ -1,0 +1,65 @@
+package com.bswap.ui.history
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import com.bswap.app.Strings
+import com.bswap.app.networkClient
+import com.bswap.app.api.WalletApi
+import com.bswap.app.models.WalletViewModel
+import com.bswap.ui.TrianglesBackground
+import com.bswap.ui.tx.TransactionRow
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.ViewModelProvider
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TransactionHistoryScreen(publicKey: String, onBack: () -> Unit, modifier: Modifier = Modifier) {
+    val client = remember { networkClient() }
+    val api = remember(client) { WalletApi(client) }
+    val vm: WalletViewModel = viewModel(factory = object : ViewModelProvider.Factory {
+        override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
+            @Suppress("UNCHECKED_CAST")
+            return WalletViewModel(api, publicKey) as T
+        }
+    })
+    val history by vm.history.collectAsState()
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = Strings.back)
+                    }
+                },
+                title = { Text(Strings.history) }
+            )
+        }
+    ) { inner ->
+        Box(modifier = modifier.fillMaxSize()) {
+            TrianglesBackground(modifier = Modifier.matchParentSize())
+            LazyColumn(modifier = Modifier
+                .fillMaxSize()
+                .padding(inner)) {
+                items(history) { tx ->
+                    TransactionRow(tx = tx)
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/home/HomeScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -85,7 +86,7 @@ class HomeViewModel(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HomeScreen(publicKey: String, onSettings: () -> Unit, modifier: Modifier = Modifier) {
+fun HomeScreen(publicKey: String, onSettings: () -> Unit, onHistory: () -> Unit, modifier: Modifier = Modifier) {
     val client = remember { networkClient() }
     val api = remember(client) { WalletApi(client) }
     val vm: HomeViewModel = viewModel(factory = object : androidx.lifecycle.ViewModelProvider.Factory {
@@ -114,6 +115,12 @@ fun HomeScreen(publicKey: String, onSettings: () -> Unit, modifier: Modifier = M
                     onClick = {},
                     icon = { Icon(Icons.Default.ArrowUpward, contentDescription = Strings.home) },
                     label = { Text(Strings.home) }
+                )
+                NavigationBarItem(
+                    selected = false,
+                    onClick = onHistory,
+                    icon = { Icon(Icons.Default.History, contentDescription = Strings.history) },
+                    label = { Text(Strings.history) }
                 )
                 NavigationBarItem(
                     selected = false,
@@ -156,14 +163,14 @@ fun HomeScreen(publicKey: String, onSettings: () -> Unit, modifier: Modifier = M
                         )
                     }
                 }
-                ActionRow()
+                ActionRow(onHistory = onHistory)
             }
         }
     }
 }
 
 @Composable
-fun ActionRow(modifier: Modifier = Modifier) {
+fun ActionRow(onHistory: () -> Unit, modifier: Modifier = Modifier) {
     Column(
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(8.dp)
@@ -183,6 +190,10 @@ fun ActionRow(modifier: Modifier = Modifier) {
         FilledTonalButton(onClick = {}, modifier = Modifier.fillMaxWidth()) {
             Icon(Icons.Default.SwapHoriz, contentDescription = Strings.swap)
             Text(Strings.swap)
+        }
+        FilledTonalButton(onClick = onHistory, modifier = Modifier.fillMaxWidth()) {
+            Icon(Icons.Default.History, contentDescription = Strings.history)
+            Text(Strings.history)
         }
     }
 }


### PR DESCRIPTION
## Summary
- provide string label for history
- support TransactionHistory route in navigation
- hook up a history screen showing recent transactions
- add History button to the home screen navigation bar and action list

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68573ea5656083338003909cffbccb49