### PR TITLE
Use Koin DI for viewmodels

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -49,6 +49,7 @@ kotlin {
             implementation(libs.ktor.client.okhttp)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.androidx.security.crypto)
+            implementation(libs.koin.android)
             implementation("org.bitcoinj:bitcoinj-core:${libs.versions.bitcoinj.get()}") {
                 exclude(group = "com.google.protobuf", module = "protobuf-javalite")
             }
@@ -65,6 +66,8 @@ kotlin {
             implementation(libs.androidx.lifecycle.viewmodel)
             implementation(libs.androidx.lifecycle.viewmodel.compose)
             implementation(libs.androidx.lifecycle.runtime.compose)
+            implementation(libs.koin.core)
+            implementation(libs.koin.compose)
             implementation(libs.ktor.serialization.kotlinx.json)
             implementation(libs.ktor.client.content.negotiation)
             implementation(libs.ktor.client.core)

--- a/composeApp/src/androidMain/kotlin/com/bswap/app/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/bswap/app/MainActivity.kt
@@ -9,10 +9,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.bswap.app.ComposeApp
 import com.bswap.navigation.rememberBackStack
 import com.bswap.navigation.pop
+import com.bswap.app.di.initKoin
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        initKoin()
 
         setContent {
             val backStack = rememberBackStack()

--- a/composeApp/src/commonMain/kotlin/com/bswap/app/ComposeApp.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/app/ComposeApp.kt
@@ -10,6 +10,7 @@ import com.bswap.navigation.replaceAll
 import com.bswap.ui.WalletTheme
 import androidx.compose.ui.tooling.preview.Preview
 import com.bswap.data.seedStorage
+import com.bswap.app.di.initKoin
 
 /**
  * Entry composable launching the Bswap navigation flow.
@@ -31,5 +32,6 @@ fun ComposeApp(backStack: SnapshotStateList<NavKey> = rememberBackStack()) {
 @Preview
 @Composable
 private fun ComposeAppPreview() {
+    initKoin()
     ComposeApp()
 }

--- a/composeApp/src/commonMain/kotlin/com/bswap/app/di/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/app/di/Koin.kt
@@ -1,0 +1,21 @@
+package com.bswap.app.di
+
+import com.bswap.app.networkClient
+import com.bswap.app.api.WalletApi
+import com.bswap.app.models.*
+import com.bswap.ui.home.HomeViewModel
+import org.koin.core.context.startKoin
+import org.koin.dsl.module
+
+val appModule = module {
+    single { networkClient() }
+    single { WalletApi(get()) }
+
+    factory { TokenViewModel(get()) }
+    factory { ConfirmSeedViewModel() }
+    factory { ExchangeRateViewModel(get()) }
+    factory { (address: String) -> WalletViewModel(get(), address) }
+    factory { (address: String) -> HomeViewModel(get(), address) }
+}
+
+fun initKoin() = startKoin { modules(appModule) }

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/history/TransactionHistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/history/TransactionHistoryScreen.kt
@@ -15,28 +15,18 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import com.bswap.app.Strings
-import com.bswap.app.networkClient
-import com.bswap.app.api.WalletApi
 import com.bswap.app.models.WalletViewModel
 import com.bswap.ui.TrianglesBackground
 import com.bswap.ui.tx.TransactionRow
-import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.lifecycle.ViewModelProvider
+import org.koin.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TransactionHistoryScreen(publicKey: String, onBack: () -> Unit, modifier: Modifier = Modifier) {
-    val client = remember { networkClient() }
-    val api = remember(client) { WalletApi(client) }
-    val vm: WalletViewModel = viewModel(factory = object : ViewModelProvider.Factory {
-        override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
-            @Suppress("UNCHECKED_CAST")
-            return WalletViewModel(api, publicKey) as T
-        }
-    })
+    val vm: WalletViewModel = koinViewModel(parameters = { parametersOf(publicKey) })
     val history by vm.history.collectAsState()
 
     Scaffold(

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/home/HomeScreen.kt
@@ -35,16 +35,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.lifecycle.ViewModelProvider
 import com.bswap.app.Strings
-import com.bswap.app.networkClient
-import com.bswap.app.api.WalletApi
-import com.bswap.app.models.WalletViewModel
 import com.bswap.ui.TrianglesBackground
 import com.bswap.ui.account.AccountHeader
 import com.bswap.ui.balance.BalanceCard
 import com.bswap.ui.token.TokenChip
+import org.koin.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -87,14 +84,7 @@ class HomeViewModel(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(publicKey: String, onSettings: () -> Unit, onHistory: () -> Unit, modifier: Modifier = Modifier) {
-    val client = remember { networkClient() }
-    val api = remember(client) { WalletApi(client) }
-    val vm: HomeViewModel = viewModel(factory = object : androidx.lifecycle.ViewModelProvider.Factory {
-        override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
-            @Suppress("UNCHECKED_CAST")
-            return HomeViewModel(api, publicKey) as T
-        }
-    })
+    val vm: HomeViewModel = koinViewModel(parameters = { parametersOf(publicKey) })
     val state by vm.uiState.collectAsState()
 
     Scaffold(

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/wallet/WalletHomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/wallet/WalletHomeScreen.kt
@@ -19,9 +19,9 @@ import com.bswap.ui.WalletTheme
 import com.bswap.ui.actions.PrimaryActionBar
 import com.bswap.ui.balance.BalanceCard
 import com.bswap.ui.token.TokenChip
-import com.bswap.app.networkClient
-import com.bswap.app.api.WalletApi
 import com.bswap.app.models.WalletViewModel
+import org.koin.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
 import com.bswap.ui.tx.TransactionRow
 import com.bswap.navigation.replaceAll
 import androidx.compose.material.icons.Icons
@@ -42,9 +42,7 @@ fun WalletHomeScreen(
     backStack: SnapshotStateList<NavKey>,
     modifier: Modifier = Modifier
 ) {
-    val client = remember { networkClient() }
-    val api = remember(client) { WalletApi(client) }
-    val viewModel = remember { WalletViewModel(api, publicKey) }
+    val viewModel: WalletViewModel = koinViewModel(parameters = { parametersOf(publicKey) })
 
     val walletInfo by viewModel.walletInfo.collectAsState()
     val loading by viewModel.isLoading.collectAsState()

--- a/composeApp/src/desktopMain/kotlin/com/bswap/app/main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/bswap/app/main.kt
@@ -4,8 +4,10 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import com.bswap.app.ComposeApp
 import com.bswap.navigation.rememberBackStack
+import com.bswap.app.di.initKoin
 
 fun main() = application {
+    initKoin()
     Window(
         onCloseRequest = ::exitApplication,
         title = "Bswap",

--- a/composeApp/src/wasmJsMain/kotlin/com/bswap/app/main.kt
+++ b/composeApp/src/wasmJsMain/kotlin/com/bswap/app/main.kt
@@ -4,10 +4,12 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeViewport
 import com.bswap.app.ComposeApp
 import com.bswap.navigation.rememberBackStack
+import com.bswap.app.di.initKoin
 import kotlinx.browser.document
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
+    initKoin()
     ComposeViewport(document.body!!) {
         val backStack = rememberBackStack()
         ComposeApp(backStack)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ bitcoinj = "0.17"
 wallet-core = "0.3.7"
 androidx-datastore = "1.0.0"
 androidx-security-crypto = "1.1.0-alpha06"
+koin = "4.1.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -74,6 +75,9 @@ bitcoinj-core = { module = "org.bitcoinj:bitcoinj-core", version.ref = "bitcoinj
 wallet-core = { module = "com.portto:walletcore", version.ref = "wallet-core" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidx-security-crypto" }
+koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
+koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
+koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add Koin 4.1.0 dependencies
- provide Koin DI module with viewmodels
- start Koin in Android, desktop and wasm entrypoints
- inject viewmodels in Compose screens with `koinViewModel`

## Testing
- `./gradlew build --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c65481f083339315081e1e53be8c