### PR TITLE
Disable wasm by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
 2. Run `./gradlew build` to fetch dependencies. The build uses Gradle's
    **configuration cache** and **parallel execution** to speed things up.
 3. Launch the backend with `./gradlew server:run`
-4. Open the browser UI via `./gradlew :composeApp:wasmJsBrowserProductionRun`
+4. To open the Compose UI in a browser, set `enableWasm=true` in `gradle.properties`
+   and run `./gradlew :composeApp:wasmJsBrowserProductionRun`
 5. To run Android unit tests, set the `ANDROID_HOME` environment variable or
    create a `local.properties` file with `sdk.dir=<path-to-sdk>`.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@ android.useAndroidX=true
 
 # Enable automatic download of required Java toolchains
 org.gradle.java.installations.auto-download=true
+enableWasm=false

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -5,9 +5,13 @@ plugins {
 }
 
 kotlin {
+    val enableWasm = project.findProperty("enableWasm") == "true"
+
     androidTarget()
     jvm()
-    wasmJs()
+    if (enableWasm) {
+        wasmJs()
+    }
 
     sourceSets {
         val commonMain by getting {
@@ -26,7 +30,9 @@ kotlin {
                 implementation(libs.wallet.core)
             }
         }
-        val wasmJsMain by getting
+        if (enableWasm) {
+            val wasmJsMain by getting
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- make the WASM target optional
- document how to enable the Compose WASM UI

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c9e4f1d083339fed4099fcb9efd8