### PR TITLE
Migrate to Koin 4.1 compose API

### DIFF
--- a/MIGRATION_KOIN_4_1.md
+++ b/MIGRATION_KOIN_4_1.md
@@ -1,0 +1,23 @@
+# Koin 4.1 Migration
+
+This project now relies on Koin `4.1.0` and the new Compose APIs.
+
+## Key changes
+
+- DI start-up is handled by `KoinApplication` and `KoinMultiplatformApplication` composables.
+- All manual `startKoin` calls were removed.
+- ViewModel injection now uses `koinViewModel()` and previews wrap content in `KoinApplicationPreview`.
+- Modules are defined in `appModule` and supplied directly to `KoinApplication` at the root composable.
+
+## Sample usage
+
+```kotlin
+@Composable
+fun BswapApp() {
+    KoinApplication(application = { modules(appModule) }) {
+        ComposeApp()
+    }
+}
+```
+
+Tests and previews should also be launched inside a `KoinApplicationPreview` block with test modules.

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -49,7 +49,6 @@ kotlin {
             implementation(libs.ktor.client.okhttp)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.androidx.security.crypto)
-            implementation(libs.koin.android)
             implementation("org.bitcoinj:bitcoinj-core:${libs.versions.bitcoinj.get()}") {
                 exclude(group = "com.google.protobuf", module = "protobuf-javalite")
             }
@@ -68,6 +67,8 @@ kotlin {
             implementation(libs.androidx.lifecycle.runtime.compose)
             implementation(libs.koin.core)
             implementation(libs.koin.compose)
+            implementation(libs.koin.compose.viewmodel)
+            implementation(libs.koin.compose.viewmodel.navigation)
             implementation(libs.ktor.serialization.kotlinx.json)
             implementation(libs.ktor.client.content.negotiation)
             implementation(libs.ktor.client.core)

--- a/composeApp/src/androidMain/kotlin/com/bswap/app/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/bswap/app/MainActivity.kt
@@ -6,16 +6,13 @@ import androidx.activity.compose.setContent
 import androidx.activity.OnBackPressedCallback
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.bswap.app.ComposeApp
+import com.bswap.app.BswapApp
 import com.bswap.navigation.rememberBackStack
 import com.bswap.navigation.pop
-import com.bswap.app.di.initKoin
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        initKoin()
-
         setContent {
             val backStack = rememberBackStack()
             onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
@@ -23,7 +20,7 @@ class MainActivity : ComponentActivity() {
                     if (backStack.size > 1) backStack.pop() else finish()
                 }
             })
-            ComposeApp(backStack)
+            BswapApp(backStack)
         }
     }
 }
@@ -31,5 +28,5 @@ class MainActivity : ComponentActivity() {
 @Preview
 @Composable
 fun AppAndroidPreview() {
-    ComposeApp()
+    BswapApp()
 }

--- a/composeApp/src/commonMain/kotlin/com/bswap/app/ComposeApp.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/app/ComposeApp.kt
@@ -10,7 +10,9 @@ import com.bswap.navigation.replaceAll
 import com.bswap.ui.WalletTheme
 import androidx.compose.ui.tooling.preview.Preview
 import com.bswap.data.seedStorage
-import com.bswap.app.di.initKoin
+import com.bswap.app.di.appModule
+import org.koin.compose.KoinApplication
+import org.koin.compose.KoinApplicationPreview
 
 /**
  * Entry composable launching the Bswap navigation flow.
@@ -28,10 +30,18 @@ fun ComposeApp(backStack: SnapshotStateList<NavKey> = rememberBackStack()) {
     }
 }
 
+@Composable
+fun BswapApp(backStack: SnapshotStateList<NavKey> = rememberBackStack()) {
+    KoinApplication(application = { modules(appModule) }) {
+        ComposeApp(backStack)
+    }
+}
+
 /** Preview of [ComposeApp]. */
 @Preview
 @Composable
 private fun ComposeAppPreview() {
-    initKoin()
-    ComposeApp()
+    KoinApplicationPreview(application = { modules(appModule) }) {
+        ComposeApp()
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/bswap/app/di/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/app/di/Koin.kt
@@ -4,7 +4,6 @@ import com.bswap.app.networkClient
 import com.bswap.app.api.WalletApi
 import com.bswap.app.models.*
 import com.bswap.ui.home.HomeViewModel
-import org.koin.core.context.startKoin
 import org.koin.dsl.module
 
 val appModule = module {
@@ -17,5 +16,3 @@ val appModule = module {
     factory { (address: String) -> WalletViewModel(get(), address) }
     factory { (address: String) -> HomeViewModel(get(), address) }
 }
-
-fun initKoin() = startKoin { modules(appModule) }

--- a/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/ConfirmSeedScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/bswap/ui/seed/ConfirmSeedScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import org.koin.compose.koinViewModel
 import com.bswap.app.models.ConfirmSeedViewModel
 import com.bswap.data.seedStorage
 import com.bswap.navigation.NavKey
@@ -49,7 +49,7 @@ fun ConfirmSeedScreen(
     mnemonic: List<String>,
     backStack: SnapshotStateList<NavKey>,
     modifier: Modifier = Modifier,
-    viewModel: ConfirmSeedViewModel = viewModel()
+    viewModel: ConfirmSeedViewModel = koinViewModel()
 ) {
     val available = remember { mutableStateListOf(*mnemonic.shuffled().toTypedArray()) }
     val selected = remember { mutableStateListOf<String>() }

--- a/composeApp/src/desktopMain/kotlin/com/bswap/app/main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/bswap/app/main.kt
@@ -2,17 +2,19 @@ package com.bswap.app
 
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
-import com.bswap.app.ComposeApp
+import com.bswap.app.BswapApp
 import com.bswap.navigation.rememberBackStack
-import com.bswap.app.di.initKoin
+import org.koin.compose.KoinMultiplatformApplication
+import com.bswap.app.di.appModule
 
 fun main() = application {
-    initKoin()
-    Window(
+    KoinMultiplatformApplication(application = { modules(appModule) }) {
+        Window(
         onCloseRequest = ::exitApplication,
         title = "Bswap",
-    ) {
-        val backStack = rememberBackStack()
-        ComposeApp(backStack)
+        ) {
+            val backStack = rememberBackStack()
+            BswapApp(backStack)
+        }
     }
 }

--- a/composeApp/src/wasmJsMain/kotlin/com/bswap/app/main.kt
+++ b/composeApp/src/wasmJsMain/kotlin/com/bswap/app/main.kt
@@ -2,16 +2,18 @@ package com.bswap.app
 
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeViewport
-import com.bswap.app.ComposeApp
+import com.bswap.app.BswapApp
 import com.bswap.navigation.rememberBackStack
-import com.bswap.app.di.initKoin
+import org.koin.compose.KoinMultiplatformApplication
+import com.bswap.app.di.appModule
 import kotlinx.browser.document
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
-    initKoin()
-    ComposeViewport(document.body!!) {
-        val backStack = rememberBackStack()
-        ComposeApp(backStack)
+    KoinMultiplatformApplication(application = { modules(appModule) }) {
+        ComposeViewport(document.body!!) {
+            val backStack = rememberBackStack()
+            BswapApp(backStack)
+        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -76,8 +76,11 @@ wallet-core = { module = "com.portto:walletcore", version.ref = "wallet-core" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidx-security-crypto" }
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
-koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin" }
+koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin" }
+koin-compose-viewmodel-navigation = { module = "io.insert-koin:koin-compose-viewmodel-navigation", version.ref = "koin" }
+koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }
+koin-androidx-compose-navigation = { module = "io.insert-koin:koin-androidx-compose-navigation", version.ref = "koin" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- update Gradle catalog with Koin 4.1 artifacts
- integrate `KoinApplication` at the root of the compose hierarchy
- remove `startKoin` usage and old android API
- update injection calls to `koinViewModel`
- add brief migration notes

## Testing
- `./gradlew :composeApp:assembleDebug` *(fails: SDK location not found)*
- `./gradlew detekt ktlint test` *(fails: task not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857cff7a7608333be28912b55b4dda3